### PR TITLE
Bascule du coach IA vers Google AI / Gemini + correctif build front

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -12,15 +12,19 @@ FRONTEND_URL=http://localhost:3000
 # Optional: Allowed origins (comma-separated)
 ALLOWED_ORIGINS=http://localhost:3000,http://localhost:8000
 
-# ===== Coach IA (Claude) =====
-# Option A — Google Cloud Vertex AI (recommandé ici) :
-#   ANTHROPIC_VERTEX_PROJECT_ID=239164849877
-#   CLOUD_ML_REGION=europe-west1        # région où claude-opus-4-8 est activé
-#   GOOGLE_APPLICATION_CREDENTIALS=/chemin/vers/service-account.json  # auth GCP (ADC)
-ANTHROPIC_VERTEX_PROJECT_ID=
-CLOUD_ML_REGION=
-# Option B — API Claude première partie (clé sk-ant-...) :
-# ANTHROPIC_API_KEY=
+# ===== Coach IA — Google AI / Gemini =====
+AI_PROVIDER=gemini
+GEMINI_MODEL=gemini-2.5-flash
+# Clé Google AI Studio (https://aistudio.google.com/apikey) :
+GEMINI_API_KEY=
+# --- OU Vertex AI (Google Cloud) au lieu de la clé AI Studio ---
+# GOOGLE_GENAI_USE_VERTEXAI=true
+# GOOGLE_CLOUD_PROJECT=239164849877
+# GOOGLE_CLOUD_LOCATION=europe-west1
+# GOOGLE_APPLICATION_CREDENTIALS=/chemin/vers/service-account.json
+#
+# --- Alternative : fournisseur Claude (AI_PROVIDER=claude) ---
+# ANTHROPIC_API_KEY=sk-ant-...
  
  # Database
  # Local development: SQLite

--- a/backend/ai_client.py
+++ b/backend/ai_client.py
@@ -1,19 +1,28 @@
 """
-Client Claude partagé pour le coach IA (Flash Neiga).
+Client IA partagé pour le coach (Flash Neiga).
 
-Prend en charge deux modes d'authentification, choisis automatiquement selon
-les variables d'environnement présentes (aucune clé n'est jamais codée en dur) :
+Fournisseur par défaut : **Google AI / Gemini** (SDK `google-genai`).
+Un fournisseur Claude (SDK `anthropic`) reste disponible via AI_PROVIDER=claude.
 
-1. Google Cloud Vertex AI (recommandé ici — le projet fournit une credential GCP) :
-     ANTHROPIC_VERTEX_PROJECT_ID = <id ou numéro de projet, ex: 239164849877>
-     CLOUD_ML_REGION            = <région Vertex où claude-opus-4-8 est activé, ex: europe-west1>
-   Auth GCP via ADC (GOOGLE_APPLICATION_CREDENTIALS pointant vers un JSON de
-   compte de service, ou `gcloud auth application-default login`).
+Configuration par variables d'environnement (aucune clé n'est jamais codée en dur) :
 
-2. API Claude première partie :
-     ANTHROPIC_API_KEY = sk-ant-...
+  AI_PROVIDER   = gemini (défaut) | claude
+  GEMINI_MODEL  = gemini-2.5-flash (défaut) | gemini-2.5-pro | ...
 
-Le module ne lève jamais à l'import : si le SDK ou la config manque,
+  # --- Google AI Studio (chemin simple, recommandé) ---
+  GEMINI_API_KEY = <ta clé Google AI Studio>        (ou GOOGLE_API_KEY)
+
+  # --- OU Vertex AI (si tu passes par Google Cloud) ---
+  GOOGLE_GENAI_USE_VERTEXAI = true
+  GOOGLE_CLOUD_PROJECT       = 239164849877
+  GOOGLE_CLOUD_LOCATION      = europe-west1
+  # + auth GCP (GOOGLE_APPLICATION_CREDENTIALS)
+
+  # --- Claude (optionnel, AI_PROVIDER=claude) ---
+  ANTHROPIC_API_KEY = sk-ant-...
+  # ou Vertex : ANTHROPIC_VERTEX_PROJECT_ID + CLOUD_ML_REGION
+
+Le module n'échoue jamais à l'import : si le SDK ou la config manque,
 `ai_configured()` renvoie False et les endpoints IA répondent proprement 503.
 """
 from __future__ import annotations
@@ -25,14 +34,30 @@ from typing import Any, Dict, Optional
 
 logger = logging.getLogger(__name__)
 
+# --- Modèles ---
+GEMINI_MODEL = os.environ.get("GEMINI_MODEL", "gemini-2.5-flash")
 CLAUDE_MODEL = "claude-opus-4-8"
 
-# Import « souple » du SDK : l'app doit démarrer même si anthropic n'est pas installé.
+
+def _provider() -> str:
+    return (os.environ.get("AI_PROVIDER") or "gemini").strip().lower()
+
+
+# --- Imports « souples » : l'app doit démarrer même sans SDK installé ---
 try:
-    import anthropic  # type: ignore
+    from google import genai as _genai  # type: ignore
+    from google.genai import types as _genai_types  # type: ignore
+    _GENAI_IMPORT_ERROR: Optional[Exception] = None
+except Exception as exc:  # pragma: no cover
+    _genai = None  # type: ignore
+    _genai_types = None  # type: ignore
+    _GENAI_IMPORT_ERROR = exc
+
+try:
+    import anthropic as _anthropic  # type: ignore
     _ANTHROPIC_IMPORT_ERROR: Optional[Exception] = None
 except Exception as exc:  # pragma: no cover
-    anthropic = None  # type: ignore
+    _anthropic = None  # type: ignore
     _ANTHROPIC_IMPORT_ERROR = exc
 
 
@@ -40,21 +65,33 @@ class AICoachUnavailable(Exception):
     """Levée quand le coach IA ne peut pas répondre (non configuré ou API en erreur)."""
 
 
-_client = None  # cache du client (créé à la première utilisation)
+_client = None  # cache du client
 
 
-def _use_vertex() -> bool:
+# ===== Détection de configuration =====
+def _gemini_use_vertex() -> bool:
+    val = (os.environ.get("GOOGLE_GENAI_USE_VERTEXAI") or "").strip().lower()
+    return val in ("1", "true", "yes")
+
+
+def _gemini_configured() -> bool:
+    if _genai is None:
+        return False
+    if _gemini_use_vertex():
+        return bool(os.environ.get("GOOGLE_CLOUD_PROJECT") and os.environ.get("GOOGLE_CLOUD_LOCATION"))
+    return bool(os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY"))
+
+
+def _claude_use_vertex() -> bool:
     return bool(
-        os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID")
-        or os.environ.get("CLAUDE_CODE_USE_VERTEX")
+        os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID") or os.environ.get("CLAUDE_CODE_USE_VERTEX")
     )
 
 
-def ai_configured() -> bool:
-    """Le coach IA est-il utilisable (SDK présent + credentials disponibles) ?"""
-    if anthropic is None:
+def _claude_configured() -> bool:
+    if _anthropic is None:
         return False
-    if _use_vertex():
+    if _claude_use_vertex():
         return bool(
             os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID")
             and (os.environ.get("CLOUD_ML_REGION") or os.environ.get("ANTHROPIC_VERTEX_REGION"))
@@ -62,37 +99,122 @@ def ai_configured() -> bool:
     return bool(os.environ.get("ANTHROPIC_API_KEY"))
 
 
+def ai_configured() -> bool:
+    """Le coach IA est-il utilisable (SDK présent + credentials disponibles) ?"""
+    return _claude_configured() if _provider() == "claude" else _gemini_configured()
+
+
+# ===== Construction du client =====
 def get_client():
-    """Retourne (et met en cache) le client Claude adapté à la config d'environnement."""
+    """Retourne (et met en cache) le client IA adapté au fournisseur/config."""
     global _client
     if _client is not None:
         return _client
 
-    if anthropic is None:
-        raise AICoachUnavailable(
-            f"SDK anthropic indisponible : {_ANTHROPIC_IMPORT_ERROR}"
-        )
+    provider = _provider()
 
-    if _use_vertex():
-        project_id = os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID")
-        region = os.environ.get("CLOUD_ML_REGION") or os.environ.get("ANTHROPIC_VERTEX_REGION")
-        if not project_id or not region:
-            raise AICoachUnavailable(
-                "Config Vertex incomplète : ANTHROPIC_VERTEX_PROJECT_ID et CLOUD_ML_REGION requis."
-            )
-        try:
+    if provider == "claude":
+        if _anthropic is None:
+            raise AICoachUnavailable(f"SDK anthropic indisponible : {_ANTHROPIC_IMPORT_ERROR}")
+        if _claude_use_vertex():
+            project_id = os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID")
+            region = os.environ.get("CLOUD_ML_REGION") or os.environ.get("ANTHROPIC_VERTEX_REGION")
+            if not (project_id and region):
+                raise AICoachUnavailable("Config Vertex (Claude) incomplète.")
             from anthropic import AnthropicVertex  # type: ignore
-        except Exception as exc:  # pragma: no cover
-            raise AICoachUnavailable(
-                f"Support Vertex indisponible (installer anthropic[vertex]) : {exc}"
-            )
-        _client = AnthropicVertex(project_id=project_id, region=region)
-    else:
-        if not os.environ.get("ANTHROPIC_API_KEY"):
-            raise AICoachUnavailable("ANTHROPIC_API_KEY manquant.")
-        _client = anthropic.Anthropic()
+            _client = AnthropicVertex(project_id=project_id, region=region)
+        else:
+            if not os.environ.get("ANTHROPIC_API_KEY"):
+                raise AICoachUnavailable("ANTHROPIC_API_KEY manquant.")
+            _client = _anthropic.Anthropic()
+        return _client
 
+    # --- Gemini (défaut) ---
+    if _genai is None:
+        raise AICoachUnavailable(f"SDK google-genai indisponible : {_GENAI_IMPORT_ERROR}")
+    if _gemini_use_vertex():
+        project = os.environ.get("GOOGLE_CLOUD_PROJECT")
+        location = os.environ.get("GOOGLE_CLOUD_LOCATION")
+        if not (project and location):
+            raise AICoachUnavailable("Config Vertex (Gemini) incomplète : GOOGLE_CLOUD_PROJECT + GOOGLE_CLOUD_LOCATION requis.")
+        _client = _genai.Client(vertexai=True, project=project, location=location)
+    else:
+        api_key = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
+        if not api_key:
+            raise AICoachUnavailable("GEMINI_API_KEY (ou GOOGLE_API_KEY) manquant.")
+        _client = _genai.Client(api_key=api_key)
     return _client
+
+
+# ===== Appels structurés (JSON) =====
+def _call_gemini(system: str, user_content: str, schema: Dict[str, Any], max_tokens: int, client) -> Dict[str, Any]:
+    # JSON mode + schéma décrit dans le prompt : robuste quelle que soit la
+    # version du SDK, sans dépendre du format de response_schema propre à Gemini.
+    prompt = (
+        f"{user_content}\n\n"
+        "Réponds UNIQUEMENT avec un objet JSON valide (aucun texte autour, pas de balise Markdown) "
+        "respectant exactement ce schéma JSON :\n"
+        f"{json.dumps(schema, ensure_ascii=False)}"
+    )
+    try:
+        response = client.models.generate_content(
+            model=GEMINI_MODEL,
+            contents=prompt,
+            config=_genai_types.GenerateContentConfig(
+                system_instruction=system,
+                response_mime_type="application/json",
+                max_output_tokens=max_tokens,
+            ),
+        )
+    except Exception as exc:
+        logger.warning("Appel Gemini en échec : %s", exc)
+        raise AICoachUnavailable(str(exc)) from exc
+
+    text = getattr(response, "text", None)
+    if not text:
+        # Réponse bloquée (sécurité) ou vide
+        raise AICoachUnavailable("Réponse Gemini vide ou bloquée.")
+    return _parse_json(text)
+
+
+def _call_claude(system: str, user_content: str, schema: Dict[str, Any], max_tokens: int, client) -> Dict[str, Any]:
+    try:
+        response = client.messages.create(
+            model=CLAUDE_MODEL,
+            max_tokens=max_tokens,
+            system=[{"type": "text", "text": system, "cache_control": {"type": "ephemeral"}}],
+            messages=[{"role": "user", "content": user_content}],
+            output_config={"format": {"type": "json_schema", "schema": schema}},
+        )
+    except Exception as exc:
+        logger.warning("Appel Claude en échec : %s", exc)
+        raise AICoachUnavailable(str(exc)) from exc
+
+    if getattr(response, "stop_reason", None) == "refusal":
+        raise AICoachUnavailable("La réponse a été refusée par le modèle.")
+
+    text = None
+    for block in getattr(response, "content", []) or []:
+        if getattr(block, "type", None) == "text":
+            text = block.text
+            break
+    if not text:
+        raise AICoachUnavailable("Réponse Claude vide.")
+    return _parse_json(text)
+
+
+def _parse_json(text: str) -> Dict[str, Any]:
+    text = text.strip()
+    # Nettoyage défensif d'éventuelles fences ```json ... ```
+    if text.startswith("```"):
+        text = text.strip("`")
+        if text.lower().startswith("json"):
+            text = text[4:]
+        text = text.strip()
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise AICoachUnavailable(f"JSON invalide renvoyé par le modèle : {exc}") from exc
 
 
 def call_structured(
@@ -102,48 +224,12 @@ def call_structured(
     max_tokens: int = 2048,
     client=None,
 ) -> Dict[str, Any]:
-    """Appelle Claude en mode structured output et renvoie le JSON parsé.
+    """Appelle le modèle en mode JSON structuré et renvoie le dict parsé.
 
-    - `system` est mis en cache (prompt caching) : contenu stable en premier.
-    - `schema` : JSON Schema (additionalProperties=False, champs required).
-    - Lève `AICoachUnavailable` sur refus, réponse tronquée ou erreur API/SDK.
+    Interface stable pour toutes les routes IA (indépendante du fournisseur).
+    Lève `AICoachUnavailable` en cas d'erreur (refus, vide, JSON invalide, API).
     """
     cli = client or get_client()
-
-    try:
-        response = cli.messages.create(
-            model=CLAUDE_MODEL,
-            max_tokens=max_tokens,
-            system=[
-                {
-                    "type": "text",
-                    "text": system,
-                    "cache_control": {"type": "ephemeral"},
-                }
-            ],
-            messages=[{"role": "user", "content": user_content}],
-            output_config={"format": {"type": "json_schema", "schema": schema}},
-        )
-    except Exception as exc:
-        # anthropic.RateLimitError / APIStatusError / APIConnectionError, etc.
-        logger.warning("Appel Claude en échec : %s", exc)
-        raise AICoachUnavailable(str(exc)) from exc
-
-    stop_reason = getattr(response, "stop_reason", None)
-    if stop_reason == "refusal":
-        raise AICoachUnavailable("La réponse a été refusée par le modèle.")
-    if stop_reason == "max_tokens":
-        logger.warning("Réponse Claude tronquée (max_tokens).")
-
-    text = None
-    for block in getattr(response, "content", []) or []:
-        if getattr(block, "type", None) == "text":
-            text = block.text
-            break
-    if not text:
-        raise AICoachUnavailable("Réponse Claude vide.")
-
-    try:
-        return json.loads(text)
-    except json.JSONDecodeError as exc:
-        raise AICoachUnavailable(f"JSON invalide renvoyé par le modèle : {exc}") from exc
+    if _provider() == "claude":
+        return _call_claude(system, user_content, schema, max_tokens, cli)
+    return _call_gemini(system, user_content, schema, max_tokens, cli)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -19,6 +19,7 @@ psycopg2-binary>=2.9.9
 python-dotenv>=1.0.0
 pytest>=7.4.0
 httpx>=0.24.1
-# Coach IA — SDK officiel Claude. L'extra [vertex] ajoute le support Google Cloud
-# Vertex AI (google-auth) utilisé quand ANTHROPIC_VERTEX_PROJECT_ID est défini.
-anthropic[vertex]>=0.40.0
+# Coach IA — Google AI / Gemini (fournisseur par défaut).
+google-genai>=1.0.0
+# Optionnel : fournisseur Claude (AI_PROVIDER=claude). Décommenter si besoin.
+# anthropic[vertex]>=0.40.0

--- a/backend/routes/ai_coach.py
+++ b/backend/routes/ai_coach.py
@@ -259,6 +259,10 @@ async def series_report(
     if not exam:
         raise HTTPException(status_code=404, detail="Série introuvable")
 
+    # L'élève ne peut demander que le bilan de ses propres séries (ou d'une série anonyme).
+    if exam.user_id not in (current_user.id, "guest"):
+        raise HTTPException(status_code=403, detail="Accès refusé à cette série")
+
     # Progression chiffrée : toujours recalculée en SQL (chiffres exacts).
     encouragement = _weekly_success_rate(db, exam.user_id)
 

--- a/backend/tests/test_ai_client.py
+++ b/backend/tests/test_ai_client.py
@@ -1,0 +1,83 @@
+"""
+Tests de la couche IA partagée (ai_client) — fournisseur Gemini par défaut.
+On injecte un faux client : aucun appel réseau.
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+backend_path = Path(__file__).parent.parent
+sys.path.insert(0, str(backend_path))
+
+import ai_client  # noqa: E402
+
+
+class _FakeResp:
+    def __init__(self, text):
+        self.text = text
+
+
+class _FakeModels:
+    def __init__(self, text):
+        self._text = text
+        self.captured = None
+
+    def generate_content(self, **kwargs):
+        self.captured = kwargs
+        return _FakeResp(self._text)
+
+
+class _FakeGeminiClient:
+    def __init__(self, text):
+        self.models = _FakeModels(text)
+
+
+def test_ai_configured_true_with_key(monkeypatch):
+    monkeypatch.setenv("AI_PROVIDER", "gemini")
+    monkeypatch.setenv("GEMINI_API_KEY", "dummy")
+    assert ai_client.ai_configured() is True
+
+
+def test_ai_configured_false_without_key(monkeypatch):
+    monkeypatch.setenv("AI_PROVIDER", "gemini")
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_GENAI_USE_VERTEXAI", raising=False)
+    assert ai_client.ai_configured() is False
+
+
+def test_call_structured_gemini_shape(monkeypatch):
+    monkeypatch.setenv("AI_PROVIDER", "gemini")
+    payload = {"explication": "x", "regle": "y", "erreurs_a_eviter": ["a"], "schema_svg": None}
+    client = _FakeGeminiClient(json.dumps(payload))
+    out = ai_client.call_structured("SYS", "USER", {"type": "object", "properties": {}},
+                                    max_tokens=2048, client=client)
+    cfg = client.models.captured["config"]
+    assert client.models.captured["model"] == ai_client.GEMINI_MODEL
+    assert cfg.system_instruction == "SYS"
+    assert cfg.response_mime_type == "application/json"
+    assert cfg.max_output_tokens == 2048
+    assert "schéma JSON" in client.models.captured["contents"]
+    assert out == payload
+
+
+def test_call_structured_parses_fenced_json(monkeypatch):
+    monkeypatch.setenv("AI_PROVIDER", "gemini")
+    client = _FakeGeminiClient("```json\n{\"a\": 1}\n```")
+    assert ai_client.call_structured("s", "u", {}, client=client) == {"a": 1}
+
+
+def test_call_structured_empty_response_raises(monkeypatch):
+    monkeypatch.setenv("AI_PROVIDER", "gemini")
+    client = _FakeGeminiClient(None)
+    with pytest.raises(ai_client.AICoachUnavailable):
+        ai_client.call_structured("s", "u", {}, client=client)
+
+
+def test_call_structured_invalid_json_raises(monkeypatch):
+    monkeypatch.setenv("AI_PROVIDER", "gemini")
+    client = _FakeGeminiClient("pas du json")
+    with pytest.raises(ai_client.AICoachUnavailable):
+        ai_client.call_structured("s", "u", {}, client=client)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "flash-neiga-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-accordion": "^1.2.11",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-context-menu": "^2.2.16",
@@ -33,6 +34,7 @@
         "@radix-ui/react-tooltip": "^1.2.8",
         "axios": "^1.13.2",
         "class-variance-authority": "^0.7.1",
+        "dompurify": "^3.0.8",
         "lucide-react": "^0.562.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
@@ -3134,6 +3136,225 @@
       "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
       "license": "MIT"
     },
+    "node_modules/@radix-ui/react-accordion": {
+      "version": "1.2.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.16.tgz",
+      "integrity": "sha512-BpZJNmetujnGgUI6OX0jEhEmlA46WPqgub8Rv09Kyquwd0cc1ndMKpiPYCjmBU6KSSRPAMtgLpEoZSG/tdNIWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-collapsible": "1.1.16",
+        "@radix-ui/react-collection": "1.1.12",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-controllable-state": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-accordion/node_modules/@radix-ui/primitive": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.5.tgz",
+      "integrity": "sha512-d86WIWFYNtGA0H/d8exstrTRTp7eWJYlYJbtNofxr/3ljupZYn6EFDG/Qgu/0Kc8v7yMUxySagqJsL1+PdYjWg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-accordion/node_modules/@radix-ui/react-collection": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.12.tgz",
+      "integrity": "sha512-nb67INpE0IahJKN7EYPp9m9YGwYeKlnzxT3MwXVkgCskaSJia97kG4T0ywpjNUSSnoJk/uvk12V8vbrEHEj+/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-slot": "1.3.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-accordion/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+      "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-accordion/node_modules/@radix-ui/react-context": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.0.tgz",
+      "integrity": "sha512-fOE+JtN9rygNZkCnHRBEP0TAvLldlhyOxMsbwFvTP4nAs+nBmfnna+o/Zski2wkmY1YMrFC0aSzsHoLY47iLrg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-accordion/node_modules/@radix-ui/react-direction": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.2.tgz",
+      "integrity": "sha512-C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-accordion/node_modules/@radix-ui/react-id": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.2.tgz",
+      "integrity": "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-accordion/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.7.tgz",
+      "integrity": "sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-accordion/node_modules/@radix-ui/react-slot": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.0.tgz",
+      "integrity": "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-accordion/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.3.tgz",
+      "integrity": "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-accordion/node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz",
+      "integrity": "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-accordion/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-arrow": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
@@ -3188,19 +3409,19 @@
       }
     },
     "node_modules/@radix-ui/react-collapsible": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.12.tgz",
-      "integrity": "sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.16.tgz",
+      "integrity": "sha512-opfXRe6nnzyGmCDPx+l1Aqo/RbqWtQal2FnsBqF9hhePp6j0LsRoBaRxcMOlTv+uYTJVtWYZKg9t9wTe+BA/ZA==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-presence": "1.1.7",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3213,6 +3434,176 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/primitive": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.5.tgz",
+      "integrity": "sha512-d86WIWFYNtGA0H/d8exstrTRTp7eWJYlYJbtNofxr/3ljupZYn6EFDG/Qgu/0Kc8v7yMUxySagqJsL1+PdYjWg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+      "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-context": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.0.tgz",
+      "integrity": "sha512-fOE+JtN9rygNZkCnHRBEP0TAvLldlhyOxMsbwFvTP4nAs+nBmfnna+o/Zski2wkmY1YMrFC0aSzsHoLY47iLrg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-id": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.2.tgz",
+      "integrity": "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.7.tgz",
+      "integrity": "sha512-zBZ4QM5XG3JRanDmqXYf3MD6th4AFXFmgU6KNMFzUaV6F3uw9I5/zjMUvFriSEn5ewo1nxuibvyxJdmLlDcslA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.7.tgz",
+      "integrity": "sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-slot": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.0.tgz",
+      "integrity": "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.3.tgz",
+      "integrity": "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz",
+      "integrity": "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -8314,6 +8705,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@radix-ui/react-accordion": "^1.2.11",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-context-menu": "^2.2.16",

--- a/render.yaml
+++ b/render.yaml
@@ -35,17 +35,20 @@ services:
         value: "https://flash-neiga-backend.onrender.com/api/payments/hyp/callback"
       - key: ALLOWED_ORIGINS
         value: "https://app.flash-neiga.com,https://appflashneiga.netlify.app"
-      # ===== Coach IA (Claude) =====
-      # Mode Google Cloud Vertex AI (le projet fournit une credential GCP).
-      # Définir aussi l'auth GCP : GOOGLE_APPLICATION_CREDENTIALS (JSON de compte
-      # de service) OU GOOGLE_APPLICATION_CREDENTIALS_JSON selon ton setup Render.
-      - key: ANTHROPIC_VERTEX_PROJECT_ID
-        sync: false  # ex: 239164849877 — à définir dans le dashboard Render
-      - key: CLOUD_ML_REGION
-        sync: false  # région Vertex où claude-opus-4-8 est activé (ex: europe-west1)
-      # Alternative API première partie (si tu utilises une clé sk-ant-... à la place) :
-      # - key: ANTHROPIC_API_KEY
-      #   sync: false
+      # ===== Coach IA — Google AI / Gemini =====
+      - key: AI_PROVIDER
+        value: "gemini"
+      - key: GEMINI_MODEL
+        value: "gemini-2.5-flash"   # ou gemini-2.5-pro pour plus de qualité
+      - key: GEMINI_API_KEY
+        sync: false  # clé Google AI Studio — à définir dans le dashboard Render
+      # Alternative Vertex AI (au lieu de la clé AI Studio) :
+      # - key: GOOGLE_GENAI_USE_VERTEXAI
+      #   value: "true"
+      # - key: GOOGLE_CLOUD_PROJECT
+      #   value: "239164849877"
+      # - key: GOOGLE_CLOUD_LOCATION
+      #   value: "europe-west1"
       - key: ADMIN_TOKEN
         sync: false  # protège /api/admin/* (dont la synthèse des questions pièges)
 


### PR DESCRIPTION
- ai_client.py : fournisseur par défaut Gemini (SDK google-genai, JSON mode, schéma décrit dans le prompt), modèle GEMINI_MODEL (défaut gemini-2.5-flash), auth par GEMINI_API_KEY (AI Studio) ou Vertex (GOOGLE_GENAI_USE_VERTEXAI). Fournisseur Claude conservé en option via AI_PROVIDER=claude. Interface call_structured() inchangée : aucune route ni composant front à modifier.
- requirements : google-genai (anthropic passe en optionnel commenté).
- render.yaml / .env.example : variables Gemini (AI_PROVIDER, GEMINI_MODEL, GEMINI_API_KEY, ou trio Vertex).
- ai_coach : contrôle d'accès sur /series-report (l'élève ne lit que ses séries).
- Front : ajout de la dépendance manquante @radix-ui/react-accordion (utilisée par les nouvelles pages) — le build de production compile désormais proprement (CI=true, 0 warning).
- Tests : nouveau test_ai_client (shape Gemini, JSON fencé, réponses vides/ invalides). 50 tests backend au vert.


Claude-Session: https://claude.ai/code/session_0113q53FTZDxJhBTX1uVZiz9