### PR TITLE
Ajout endpoint diagnostic GET /api/ai-coach/health (sans secret)

### DIFF
--- a/backend/ai_client.py
+++ b/backend/ai_client.py
@@ -104,6 +104,46 @@ def ai_configured() -> bool:
     return _claude_configured() if _provider() == "claude" else _gemini_configured()
 
 
+def diagnostics() -> Dict[str, Any]:
+    """État de configuration du coach IA — sans jamais exposer de secret.
+    Sert à comprendre un 503 en production (SDK manquant ? clé absente ?)."""
+    provider = _provider()
+    if provider == "claude":
+        sdk_installed = _anthropic is not None
+        use_vertex = _claude_use_vertex()
+        has_credentials = bool(
+            os.environ.get("ANTHROPIC_API_KEY")
+            or (use_vertex and os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID"))
+        )
+        sdk_name = "anthropic"
+        model = CLAUDE_MODEL
+    else:
+        sdk_installed = _genai is not None
+        use_vertex = _gemini_use_vertex()
+        has_credentials = bool(
+            (os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY"))
+            or (use_vertex and os.environ.get("GOOGLE_CLOUD_PROJECT") and os.environ.get("GOOGLE_CLOUD_LOCATION"))
+        )
+        sdk_name = "google-genai"
+        model = GEMINI_MODEL
+
+    reason = "ok"
+    if not sdk_installed:
+        reason = f"SDK '{sdk_name}' non installé sur le serveur"
+    elif not has_credentials:
+        reason = "credentials manquantes (clé API ou config Vertex non définie)"
+
+    return {
+        "provider": provider,
+        "model": model,
+        "sdk_installed": sdk_installed,
+        "has_credentials": has_credentials,
+        "use_vertex": use_vertex,
+        "configured": ai_configured(),
+        "reason": reason,
+    }
+
+
 # ===== Construction du client =====
 def get_client():
     """Retourne (et met en cache) le client IA adapté au fournisseur/config."""

--- a/backend/routes/ai_coach.py
+++ b/backend/routes/ai_coach.py
@@ -23,14 +23,14 @@ try:
         QuestionDB, CourseDB, ExamSessionDB, AILessonDB, SeriesReportDB, User,
     )
     from auth import get_current_user
-    from ai_client import call_structured, ai_configured, AICoachUnavailable
+    from ai_client import call_structured, ai_configured, AICoachUnavailable, diagnostics
 except ImportError:  # pragma: no cover
     from backend.database import get_db
     from backend.models import (
         QuestionDB, CourseDB, ExamSessionDB, AILessonDB, SeriesReportDB, User,
     )
     from backend.auth import get_current_user
-    from backend.ai_client import call_structured, ai_configured, AICoachUnavailable
+    from backend.ai_client import call_structured, ai_configured, AICoachUnavailable, diagnostics
 
 logger = logging.getLogger(__name__)
 
@@ -207,6 +207,12 @@ def _weekly_success_rate(db: Session, user_id: str) -> Dict[str, Any]:
 
 
 # ===== Endpoints =====
+@router.get("/health")
+async def ai_health():
+    """État de configuration du coach IA (pour diagnostiquer un 503). Sans secret."""
+    return diagnostics()
+
+
 @router.post("/lesson")
 async def generate_lesson(
     payload: dict,


### PR DESCRIPTION
Permet de comprendre un 503 en prod : indique le fournisseur, si le SDK est installé, si les credentials sont présentes, et la raison exacte — sans jamais exposer la clé.


Claude-Session: https://claude.ai/code/session_0113q53FTZDxJhBTX1uVZiz9