### PR TITLE
Leçon : budget de tokens 2048->8192 (SVG lourd) + exposer la vraie ra…

### DIFF
--- a/backend/routes/ai_coach.py
+++ b/backend/routes/ai_coach.py
@@ -153,7 +153,7 @@ def get_or_create_lesson(db: Session, question: QuestionDB, selected_option_id: 
         system=PROF_SYSTEM_PROMPT,
         user_content=user_content,
         schema=LESSON_SCHEMA,
-        max_tokens=2048,
+        max_tokens=8192,  # marge pour un éventuel schéma SVG (tokens lourds)
     )
 
     try:
@@ -274,8 +274,8 @@ async def generate_lesson(
 
     try:
         return get_or_create_lesson(db, question, selected_option_id)
-    except AICoachUnavailable:
-        raise HTTPException(status_code=503, detail=AI_UNAVAILABLE_MSG)
+    except AICoachUnavailable as exc:
+        raise HTTPException(status_code=503, detail=f"{AI_UNAVAILABLE_MSG} [{str(exc)[:300]}]")
 
 
 @router.post("/series-report")
@@ -385,8 +385,8 @@ async def series_report(
             schema=SERIES_REPORT_SCHEMA,
             max_tokens=8000,
         )
-    except AICoachUnavailable:
-        raise HTTPException(status_code=503, detail=AI_UNAVAILABLE_MSG)
+    except AICoachUnavailable as exc:
+        raise HTTPException(status_code=503, detail=f"{AI_UNAVAILABLE_MSG} [{str(exc)[:300]}]")
 
     try:
         db.add(SeriesReportDB(

--- a/backend/routes/trap_questions.py
+++ b/backend/routes/trap_questions.py
@@ -182,8 +182,8 @@ async def generate_trap_synthesis(
             schema=SYNTHESIS_SCHEMA,
             max_tokens=8000,
         )
-    except AICoachUnavailable:
-        raise HTTPException(status_code=503, detail=AI_UNAVAILABLE_MSG)
+    except AICoachUnavailable as exc:
+        raise HTTPException(status_code=503, detail=f"{AI_UNAVAILABLE_MSG} [{str(exc)[:300]}]")
 
     try:
         # On ne garde que la dernière synthèse


### PR DESCRIPTION
…ison dans le 503

Le petit self-test passe mais la leçon (avec schéma SVG) dépassait 2048 tokens -> JSON tronqué -> parse KO -> 503. On monte le budget, et les 503 des endpoints IA incluent désormais la raison réelle ([finish_reason=..., etc.]) pour diagnostic.


Claude-Session: https://claude.ai/code/session_0113q53FTZDxJhBTX1uVZiz9