### PR TITLE
Parsing JSON robuste : ne garder que le 1er objet (raw_decode) -> cor…

### DIFF
--- a/backend/ai_client.py
+++ b/backend/ai_client.py
@@ -291,10 +291,23 @@ def _parse_json(text: str) -> Dict[str, Any]:
         if text.lower().startswith("json"):
             text = text[4:]
         text = text.strip()
+
+    decoder = json.JSONDecoder()
+    # 1) Premier objet JSON à partir du début (ignore tout "Extra data" qui suit).
     try:
-        return json.loads(text)
-    except json.JSONDecodeError as exc:
-        raise AICoachUnavailable(f"JSON invalide renvoyé par le modèle : {exc}") from exc
+        obj, _ = decoder.raw_decode(text)
+        return obj
+    except json.JSONDecodeError:
+        pass
+    # 2) Sinon, on cherche le premier '{' (au cas où le modèle ajoute du texte avant).
+    start = text.find("{")
+    if start != -1:
+        try:
+            obj, _ = decoder.raw_decode(text[start:])
+            return obj
+        except json.JSONDecodeError as exc:
+            raise AICoachUnavailable(f"JSON invalide renvoyé par le modèle : {exc}") from exc
+    raise AICoachUnavailable("Réponse du modèle sans JSON exploitable.")
 
 
 def call_structured(

--- a/backend/tests/test_ai_client.py
+++ b/backend/tests/test_ai_client.py
@@ -69,6 +69,19 @@ def test_call_structured_parses_fenced_json(monkeypatch):
     assert ai_client.call_structured("s", "u", {}, client=client) == {"a": 1}
 
 
+def test_call_structured_ignores_extra_data(monkeypatch):
+    # Le modèle renvoie un objet valide puis du contenu en trop -> on garde le 1er objet.
+    monkeypatch.setenv("AI_PROVIDER", "gemini")
+    client = _FakeGeminiClient('{"a": 1, "b": "x"}\n\nvoici mon explication en trop')
+    assert ai_client.call_structured("s", "u", {}, client=client) == {"a": 1, "b": "x"}
+
+
+def test_call_structured_handles_leading_text(monkeypatch):
+    monkeypatch.setenv("AI_PROVIDER", "gemini")
+    client = _FakeGeminiClient('Bien sûr !\n{"a": 1}')
+    assert ai_client.call_structured("s", "u", {}, client=client) == {"a": 1}
+
+
 def test_call_structured_empty_response_raises(monkeypatch):
     monkeypatch.setenv("AI_PROVIDER", "gemini")
     client = _FakeGeminiClient(None)


### PR DESCRIPTION
…rige 'Extra data'

Gemini renvoie parfois l'objet JSON suivi de texte en trop malgré le JSON mode ; raw_decode décode le premier objet et ignore le surplus (et gère aussi un éventuel texte d'introduction avant le '{'). +2 tests.


Claude-Session: https://claude.ai/code/session_0113q53FTZDxJhBTX1uVZiz9