### PR TITLE
Chatbot « prof 24h/24 » : question/réponse en langage libre

### DIFF
--- a/backend/ai_client.py
+++ b/backend/ai_client.py
@@ -310,6 +310,78 @@ def _parse_json(text: str) -> Dict[str, Any]:
     raise AICoachUnavailable("Réponse du modèle sans JSON exploitable.")
 
 
+def _chat_gemini(system: str, history: list, max_tokens: int, client) -> str:
+    contents = []
+    for msg in history:
+        role = "model" if msg.get("role") == "assistant" else "user"
+        text = (msg.get("content") or "").strip()
+        if not text:
+            continue
+        contents.append(_genai_types.Content(role=role, parts=[_genai_types.Part(text=text)]))
+    if not contents:
+        raise AICoachUnavailable("Message vide.")
+
+    def _cfg(with_thinking: bool):
+        kwargs: Dict[str, Any] = dict(system_instruction=system, max_output_tokens=max_tokens)
+        if with_thinking and hasattr(_genai_types, "ThinkingConfig"):
+            kwargs["thinking_config"] = _genai_types.ThinkingConfig(thinking_budget=_thinking_budget())
+        return _genai_types.GenerateContentConfig(**kwargs)
+
+    def _do(with_thinking: bool):
+        return client.models.generate_content(model=GEMINI_MODEL, contents=contents, config=_cfg(with_thinking))
+
+    try:
+        response = _do(with_thinking=True)
+    except Exception:
+        try:
+            response = _do(with_thinking=False)
+        except Exception as exc2:
+            logger.warning("Chat Gemini en échec : %s", exc2)
+            raise AICoachUnavailable(str(exc2)) from exc2
+
+    text = getattr(response, "text", None)
+    if not text:
+        raise AICoachUnavailable(f"Réponse Gemini vide ou bloquée ({_describe_empty(response)}).")
+    return text.strip()
+
+
+def _chat_claude(system: str, history: list, max_tokens: int, client) -> str:
+    messages = [
+        {"role": ("assistant" if m.get("role") == "assistant" else "user"), "content": m.get("content") or ""}
+        for m in history if (m.get("content") or "").strip()
+    ]
+    if not messages:
+        raise AICoachUnavailable("Message vide.")
+    try:
+        response = client.messages.create(
+            model=CLAUDE_MODEL,
+            max_tokens=max_tokens,
+            system=[{"type": "text", "text": system, "cache_control": {"type": "ephemeral"}}],
+            messages=messages,
+        )
+    except Exception as exc:
+        logger.warning("Chat Claude en échec : %s", exc)
+        raise AICoachUnavailable(str(exc)) from exc
+    if getattr(response, "stop_reason", None) == "refusal":
+        raise AICoachUnavailable("La réponse a été refusée par le modèle.")
+    for block in getattr(response, "content", []) or []:
+        if getattr(block, "type", None) == "text":
+            return block.text.strip()
+    raise AICoachUnavailable("Réponse Claude vide.")
+
+
+def call_chat(system: str, history: list, max_tokens: int = 2048, client=None) -> str:
+    """Conversation libre (multi-tours) avec le prof IA.
+
+    `history` : liste de {role: "user"|"assistant", content: str}, se terminant
+    par le dernier message de l'élève. Renvoie la réponse texte du prof.
+    """
+    cli = client or get_client()
+    if _provider() == "claude":
+        return _chat_claude(system, history, max_tokens, cli)
+    return _chat_gemini(system, history, max_tokens, cli)
+
+
 def call_structured(
     system: str,
     user_content: str,

--- a/backend/routes/ai_coach.py
+++ b/backend/routes/ai_coach.py
@@ -23,14 +23,14 @@ try:
         QuestionDB, CourseDB, ExamSessionDB, AILessonDB, SeriesReportDB, User,
     )
     from auth import get_current_user
-    from ai_client import call_structured, ai_configured, AICoachUnavailable, diagnostics
+    from ai_client import call_structured, call_chat, ai_configured, AICoachUnavailable, diagnostics
 except ImportError:  # pragma: no cover
     from backend.database import get_db
     from backend.models import (
         QuestionDB, CourseDB, ExamSessionDB, AILessonDB, SeriesReportDB, User,
     )
     from backend.auth import get_current_user
-    from backend.ai_client import call_structured, ai_configured, AICoachUnavailable, diagnostics
+    from backend.ai_client import call_structured, call_chat, ai_configured, AICoachUnavailable, diagnostics
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +47,19 @@ PROF_SYSTEM_PROMPT = (
     "question fournit une explication officielle, appuie-toi dessus en "
     "priorité. Ne mentionne jamais que tu es une IA."
 )
+
+CHAT_SYSTEM_PROMPT = (
+    "Tu es le prof de code de la route israélien de l'élève, disponible 24h/24 "
+    "sur le site Flash Neiga. Tu réponds en français, tu tutoies l'élève, avec "
+    "des réponses claires, courtes et concrètes, toujours exactes vis-à-vis du "
+    "code de la route et de la conduite en Israël. Utilise des exemples et, si "
+    "utile, des listes à puces. Si la question n'a rien à voir avec la conduite, "
+    "le code de la route israélien ou la préparation à l'examen, recentre "
+    "gentiment l'élève sur ces sujets. Ne donne jamais de conseils dangereux ou "
+    "illégaux. Ne mentionne jamais que tu es une IA."
+)
+
+MAX_CHAT_HISTORY = 20  # nombre de messages récents conservés par tour
 
 # ===== Schémas structured outputs =====
 LESSON_SCHEMA: Dict[str, Any] = {
@@ -239,6 +252,46 @@ async def ai_selftest(current_user: User = Depends(get_current_user)):
         return {"ok": False, "error": str(exc)[:500], "diagnostics": diagnostics()}
     except Exception as exc:  # filet de sécurité : on renvoie l'erreur au lieu d'un 500 opaque
         return {"ok": False, "error": f"{type(exc).__name__}: {str(exc)[:500]}", "diagnostics": diagnostics()}
+
+
+@router.post("/chat")
+async def chat(
+    payload: dict,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Chatbot « prof 24h/24 » : conversation libre en français.
+
+    Body : { messages: [{role: "user"|"assistant", content: str}], context?: str }
+    Le backend est sans état : le front renvoie l'historique récent à chaque tour.
+    """
+    messages = payload.get("messages")
+    if not isinstance(messages, list) or not messages:
+        raise HTTPException(status_code=400, detail="messages requis")
+
+    # Nettoyage + on ne garde que les derniers échanges
+    history = [
+        {"role": ("assistant" if m.get("role") == "assistant" else "user"),
+         "content": str(m.get("content") or "").strip()}
+        for m in messages if str(m.get("content") or "").strip()
+    ][-MAX_CHAT_HISTORY:]
+    if not history or history[-1]["role"] != "user":
+        raise HTTPException(status_code=400, detail="Le dernier message doit venir de l'élève.")
+
+    if not ai_configured():
+        raise HTTPException(status_code=503, detail=AI_UNAVAILABLE_MSG)
+
+    system = CHAT_SYSTEM_PROMPT
+    context = str(payload.get("context") or "").strip()
+    if context:
+        system += f"\n\nContexte de l'élève (question en cours) : {context[:1500]}"
+
+    try:
+        reply = call_chat(system=system, history=history, max_tokens=2048)
+    except AICoachUnavailable as exc:
+        raise HTTPException(status_code=503, detail=f"{AI_UNAVAILABLE_MSG} [{str(exc)[:300]}]")
+
+    return {"reply": reply}
 
 
 @router.post("/lesson")

--- a/backend/tests/test_ai_coach.py
+++ b/backend/tests/test_ai_coach.py
@@ -144,6 +144,40 @@ def test_lesson_missing_question(db):
     assert r.status_code == 404
 
 
+# ===== Chatbot =====
+def test_chat_reply(db, monkeypatch):
+    captured = {}
+
+    def fake_chat(system, history, **kwargs):
+        captured["system"] = system
+        captured["history"] = history
+        return "En Israël, la priorité à droite s'applique sauf panneau contraire."
+
+    monkeypatch.setattr(ai_coach, "call_chat", fake_chat)
+
+    r = client.post("/api/ai-coach/chat", json={
+        "messages": [
+            {"role": "user", "content": "C'est quoi la priorité à droite ?"},
+        ],
+    })
+    assert r.status_code == 200
+    assert "priorité" in r.json()["reply"].lower()
+    assert captured["history"][-1]["role"] == "user"
+
+
+def test_chat_requires_last_user_message(db):
+    r = client.post("/api/ai-coach/chat", json={
+        "messages": [{"role": "assistant", "content": "Bonjour"}],
+    })
+    assert r.status_code == 400
+
+
+def test_chat_503_when_ai_unavailable(db, monkeypatch):
+    monkeypatch.setattr(ai_coach, "ai_configured", lambda: False)
+    r = client.post("/api/ai-coach/chat", json={"messages": [{"role": "user", "content": "salut"}]})
+    assert r.status_code == 503
+
+
 # ===== Phase 3 : bilan de série + encouragement chiffré =====
 def test_series_report_and_encouragement(db, monkeypatch):
     now = datetime.utcnow()

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -9,6 +9,7 @@ import ExamDetails from "./pages/ExamDetails";
 import Training from "./pages/Training";
 import Mistakes from "./pages/Mistakes";
 import TrapQuestions from "./pages/TrapQuestions";
+import ChatWidget from "./components/ChatWidget";
 import Signs from "./pages/Signs";
 import Stats from "./pages/Stats";
 import Admin from "./pages/Admin";
@@ -28,8 +29,13 @@ const ProtectedRoute = () => {
     const { isAuthenticated, loading } = useAuth();
     
     if (loading) return <div className="flex h-screen items-center justify-center text-slate-900 dark:text-white">Chargement...</div>;
-    
-    return isAuthenticated ? <Outlet /> : <Navigate to="/login" />;
+
+    return isAuthenticated ? (
+        <>
+            <Outlet />
+            <ChatWidget />
+        </>
+    ) : <Navigate to="/login" />;
 };
 
 function App() {

--- a/frontend/src/components/ChatWidget.js
+++ b/frontend/src/components/ChatWidget.js
@@ -1,0 +1,133 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import axios from 'axios';
+import { Button } from './ui/button';
+import { MessageCircle, Send, X, Loader2, GraduationCap } from 'lucide-react';
+
+const WELCOME = {
+    role: 'assistant',
+    content: "Salut 👋 Je suis ton prof de code, dispo 24h/24. Pose-moi n'importe quelle question sur le code de la route israélien ou la conduite : priorités, panneaux, distances, alcoolémie… Je t'explique simplement !",
+};
+
+/**
+ * Chatbot flottant « prof 24h/24 ». Bulle en bas à droite qui ouvre un panneau
+ * de conversation. Backend sans état : on renvoie l'historique récent à chaque tour.
+ * Masqué pendant un examen en cours (/exam) pour ne pas fausser l'épreuve.
+ */
+export default function ChatWidget() {
+    const location = useLocation();
+    const [open, setOpen] = useState(false);
+    const [messages, setMessages] = useState([WELCOME]);
+    const [input, setInput] = useState('');
+    const [loading, setLoading] = useState(false);
+    const scrollRef = useRef(null);
+
+    useEffect(() => {
+        if (scrollRef.current) {
+            scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+        }
+    }, [messages, open, loading]);
+
+    // Pas de chatbot pendant un examen blanc en cours.
+    if (location.pathname === '/exam') return null;
+
+    const send = async () => {
+        const text = input.trim();
+        if (!text || loading) return;
+        const next = [...messages, { role: 'user', content: text }];
+        setMessages(next);
+        setInput('');
+        setLoading(true);
+        try {
+            // On envoie l'historique sans le message de bienvenue (purement UI).
+            const payload = next.filter((m) => m !== WELCOME).map((m) => ({ role: m.role, content: m.content }));
+            const res = await axios.post('/api/ai-coach/chat', { messages: payload });
+            setMessages((prev) => [...prev, { role: 'assistant', content: res.data.reply }]);
+        } catch (e) {
+            const detail = e.response?.data?.detail || "Le prof est momentanément indisponible, réessaie dans un instant.";
+            setMessages((prev) => [...prev, { role: 'assistant', content: detail, error: true }]);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const onKeyDown = (e) => {
+        if (e.key === 'Enter' && !e.shiftKey) {
+            e.preventDefault();
+            send();
+        }
+    };
+
+    return (
+        <>
+            {/* Bulle flottante */}
+            {!open && (
+                <button
+                    onClick={() => setOpen(true)}
+                    aria-label="Ouvrir le chat avec le prof"
+                    className="fixed bottom-5 right-5 z-50 flex items-center gap-2 rounded-full bg-sky-600 hover:bg-sky-500 text-white px-5 py-3 shadow-xl transition-transform hover:scale-105"
+                >
+                    <MessageCircle className="h-5 w-5" />
+                    <span className="font-semibold hidden sm:inline">Demande à ton prof</span>
+                </button>
+            )}
+
+            {/* Panneau de chat */}
+            {open && (
+                <div className="fixed bottom-5 right-5 z-50 flex flex-col w-[92vw] max-w-sm h-[70vh] max-h-[560px] rounded-2xl overflow-hidden shadow-2xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900">
+                    {/* En-tête */}
+                    <div className="flex items-center justify-between px-4 py-3 bg-sky-600 text-white">
+                        <div className="flex items-center gap-2">
+                            <GraduationCap className="h-5 w-5" />
+                            <span className="font-semibold">Ton prof de code</span>
+                        </div>
+                        <button onClick={() => setOpen(false)} aria-label="Fermer" className="hover:opacity-80">
+                            <X className="h-5 w-5" />
+                        </button>
+                    </div>
+
+                    {/* Messages */}
+                    <div ref={scrollRef} className="flex-1 overflow-y-auto p-3 space-y-3 bg-slate-50 dark:bg-slate-950">
+                        {messages.map((m, i) => (
+                            <div key={i} className={`flex ${m.role === 'user' ? 'justify-end' : 'justify-start'}`}>
+                                <div
+                                    className={`max-w-[85%] rounded-2xl px-3 py-2 text-sm whitespace-pre-line ${
+                                        m.role === 'user'
+                                            ? 'bg-sky-600 text-white rounded-br-sm'
+                                            : m.error
+                                                ? 'bg-red-100 dark:bg-red-950/40 text-red-800 dark:text-red-200 rounded-bl-sm'
+                                                : 'bg-white dark:bg-slate-800 text-slate-800 dark:text-slate-100 border border-slate-200 dark:border-slate-700 rounded-bl-sm'
+                                    }`}
+                                >
+                                    {m.content}
+                                </div>
+                            </div>
+                        ))}
+                        {loading && (
+                            <div className="flex justify-start">
+                                <div className="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-2xl rounded-bl-sm px-3 py-2 text-sm text-slate-500 dark:text-slate-400 flex items-center gap-2">
+                                    <Loader2 className="h-4 w-4 animate-spin" /> Ton prof réfléchit…
+                                </div>
+                            </div>
+                        )}
+                    </div>
+
+                    {/* Saisie */}
+                    <div className="p-3 border-t border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 flex items-end gap-2">
+                        <textarea
+                            value={input}
+                            onChange={(e) => setInput(e.target.value)}
+                            onKeyDown={onKeyDown}
+                            rows={1}
+                            placeholder="Pose ta question…"
+                            className="flex-1 resize-none max-h-28 rounded-xl border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-slate-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-sky-500"
+                        />
+                        <Button onClick={send} disabled={loading || !input.trim()} size="icon" className="shrink-0 rounded-xl">
+                            <Send className="h-4 w-4" />
+                        </Button>
+                    </div>
+                </div>
+            )}
+        </>
+    );
+}


### PR DESCRIPTION
Backend :
- ai_client.call_chat() : conversation multi-tours en texte libre (Gemini + Claude), thinking désactivé, réponse texte.
- POST /api/ai-coach/chat (auth) : sans état, le front renvoie l'historique récent (plafonné à 20 messages), prompt système dédié qui recentre sur le code de la route israélien et refuse les conseils dangereux. Contexte optionnel (question en cours). 503 propre si IA indispo.
- Tests : réponse, dernier message = élève requis, 503 sans IA (55 au total).

Frontend :
- ChatWidget : bulle flottante + panneau de chat sur toutes les pages authentifiées, masqué pendant un examen en cours. Build CI OK.


Claude-Session: https://claude.ai/code/session_0113q53FTZDxJhBTX1uVZiz9