### PR TITLE
Leçons IA : plus aucune image/schema SVG dans le rendu (texte uniquem…

### DIFF
--- a/backend/routes/ai_coach.py
+++ b/backend/routes/ai_coach.py
@@ -68,7 +68,6 @@ LESSON_SCHEMA: Dict[str, Any] = {
         "explication": {"type": "string"},
         "regle": {"type": "string"},
         "erreurs_a_eviter": {"type": "array", "items": {"type": "string"}},
-        "schema_svg": {"type": ["string", "null"]},
     },
     "required": ["explication", "regle", "erreurs_a_eviter"],
     "additionalProperties": False,
@@ -156,10 +155,9 @@ def get_or_create_lesson(db: Session, question: QuestionDB, selected_option_id: 
     if question.explanation:
         user_content += f"\nExplication officielle : {question.explanation}\n"
     user_content += (
-        "\nProduis une mini-leçon. Le champ schema_svg doit contenir un schéma SVG "
-        "autonome (balise <svg> complète, ~300x200, texte en français) UNIQUEMENT si "
-        "un schéma aide vraiment (priorités, distances, intersections, panneaux) ; "
-        "sinon mets-le à null."
+        "\nProduis une mini-leçon uniquement en texte : une explication claire, "
+        "un rappel de la règle, et les erreurs à éviter. N'inclus aucune image, "
+        "aucun schéma, aucun SVG."
     )
 
     lesson = call_structured(

--- a/frontend/src/components/AiLesson.js
+++ b/frontend/src/components/AiLesson.js
@@ -4,7 +4,6 @@ import { Button } from './ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from './ui/dialog';
 import { GraduationCap, BookOpen, AlertTriangle, Lightbulb, Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
-import { sanitizeSvg } from '../lib/sanitize';
 import InlineChat from './InlineChat';
 
 /**
@@ -40,8 +39,6 @@ export default function AiLesson({ questionId, selectedOptionId, label, variant 
             setLoading(false);
         }
     };
-
-    const cleanSvg = lesson?.schema_svg ? sanitizeSvg(lesson.schema_svg) : '';
 
     return (
         <>
@@ -107,17 +104,6 @@ export default function AiLesson({ questionId, selectedOptionId, label, variant 
                                             </li>
                                         ))}
                                     </ul>
-                                </section>
-                            )}
-
-                            {/* Schéma SVG (optionnel) */}
-                            {cleanSvg && (
-                                <section>
-                                    <h4 className="font-semibold text-slate-900 dark:text-white mb-2">Le schéma</h4>
-                                    <div
-                                        className="flex justify-center rounded-xl border border-slate-200 dark:border-slate-700 bg-white p-3"
-                                        dangerouslySetInnerHTML={{ __html: cleanSvg }}
-                                    />
                                 </section>
                             )}
 


### PR DESCRIPTION
…ent)

Retrait du champ schema_svg du schema, de l'instruction SVG dans le prompt, et de l'affichage SVG + import inutilise cote front. La lecon est desormais 100 pourcent texte (explication, regle, erreurs a eviter).


Claude-Session: https://claude.ai/code/session_0113q53FTZDxJhBTX1uVZiz9