### PR TITLE
Profil utilisateur : prénom/nom à l'inscription + page profil (éditio…

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -56,7 +56,12 @@ async def get_current_user(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="User not found",
         )
-    return User(id=user.id, email=user.email)
+    return User(
+        id=user.id,
+        email=user.email,
+        first_name=getattr(user, "first_name", None),
+        last_name=getattr(user, "last_name", None),
+    )
 
 
 # Version « soft » de l'authentification : ne lève jamais d'erreur.

--- a/backend/database.py
+++ b/backend/database.py
@@ -59,6 +59,7 @@ def ensure_schema_updated():
         expected_columns = {
             'traffic_signs': ['id', 'number', 'name', 'description', 'image_url', 'category', 'explanation', 'created_at'],
             'questions': ['id', 'text', 'category', 'options', 'explanation', 'created_at'],
+            'users': ['id', 'email', 'hashed_password', 'first_name', 'last_name', 'created_at'],
         }
         
         # Check each table

--- a/backend/models.py
+++ b/backend/models.py
@@ -21,6 +21,8 @@ class UserDB(Base):
     id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
     email = Column(String, unique=True, index=True, nullable=False)
     hashed_password = Column(String, nullable=False)
+    first_name = Column(String, nullable=True)
+    last_name = Column(String, nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow)
 
 class QuestionDB(Base):
@@ -240,6 +242,9 @@ class TrafficSign(TrafficSignCreate):
 class UserCreate(BaseModel):
     email: EmailStr
     password: str
+    first_name: Optional[str] = None
+    last_name: Optional[str] = None
+    full_name: Optional[str] = None  # compat ascendante (ancien formulaire)
 
 
 class UserInDB(UserCreate):
@@ -249,6 +254,13 @@ class UserInDB(UserCreate):
 class User(BaseModel):
     id: str
     email: str
+    first_name: Optional[str] = None
+    last_name: Optional[str] = None
+
+
+class ProfileUpdate(BaseModel):
+    first_name: Optional[str] = None
+    last_name: Optional[str] = None
 
 
 class ExamSession(BaseModel):

--- a/backend/routes/profile.py
+++ b/backend/routes/profile.py
@@ -1,0 +1,148 @@
+"""
+Profil utilisateur (Flash Neiga).
+
+- GET  /api/profile                       → infos du compte + abonnement courant
+- PATCH /api/profile                      → modifier prénom / nom
+- POST /api/profile/subscription/cancel   → résilier (ne pas renouveler) l'abonnement actif
+
+« Passer à un abonnement supérieur » se fait via la page Tarifs (flux de paiement HYP) :
+le front y renvoie l'utilisateur. La résiliation marque l'abonnement comme annulé côté
+application ; l'accès reste valable jusqu'à sa date de fin (plans à durée déterminée).
+"""
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+try:
+    from database import get_db
+    from models import UserDB, SubscriptionDB, User, ProfileUpdate
+    from auth import get_current_user
+except ImportError:  # pragma: no cover
+    from backend.database import get_db
+    from backend.models import UserDB, SubscriptionDB, User, ProfileUpdate
+    from backend.auth import get_current_user
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/profile", tags=["profile"])
+
+PLANS_FILE = Path(__file__).parent.parent.parent / "hyp_plans.json"
+try:
+    with open(PLANS_FILE, "r", encoding="utf-8") as f:
+        PLANS: Dict[str, Any] = json.load(f)
+except Exception:  # pragma: no cover
+    PLANS = {}
+
+
+def _active_subscription(db: Session, user_id: str) -> Optional[SubscriptionDB]:
+    """Abonnement actif de l'élève, sinon le plus récent (pour l'historique)."""
+    active = (
+        db.query(SubscriptionDB)
+        .filter(SubscriptionDB.user_id == user_id, SubscriptionDB.status == "active")
+        .order_by(SubscriptionDB.created_at.desc())
+        .first()
+    )
+    if active:
+        return active
+    return (
+        db.query(SubscriptionDB)
+        .filter(SubscriptionDB.user_id == user_id)
+        .order_by(SubscriptionDB.created_at.desc())
+        .first()
+    )
+
+
+def _subscription_payload(sub: Optional[SubscriptionDB]) -> Optional[Dict[str, Any]]:
+    if not sub:
+        return None
+    plan = PLANS.get(sub.plan_id or "", {})
+    now = datetime.utcnow()
+    is_active = sub.status == "active" and (sub.end_date is None or sub.end_date > now)
+    return {
+        "plan_id": sub.plan_id,
+        "plan_name": plan.get("name") or sub.plan_id or "Abonnement",
+        "plan_description": plan.get("description"),
+        "amount": plan.get("amount"),
+        "currency": plan.get("currency"),
+        "status": sub.status,
+        "is_active": is_active,
+        "start_date": sub.start_date,
+        "end_date": sub.end_date,
+        "canceled_at": sub.canceled_at,
+    }
+
+
+@router.get("")
+async def get_profile(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    user = db.query(UserDB).filter(UserDB.id == current_user.id).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="Utilisateur introuvable")
+
+    sub = _active_subscription(db, user.id)
+    sub_payload = _subscription_payload(sub)
+    return {
+        "id": user.id,
+        "email": user.email,
+        "first_name": user.first_name,
+        "last_name": user.last_name,
+        "created_at": user.created_at,
+        "subscription": sub_payload,
+        "has_active_subscription": bool(sub_payload and sub_payload["is_active"]),
+    }
+
+
+@router.patch("")
+async def update_profile(
+    payload: ProfileUpdate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    user = db.query(UserDB).filter(UserDB.id == current_user.id).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="Utilisateur introuvable")
+
+    if payload.first_name is not None:
+        user.first_name = payload.first_name.strip() or None
+    if payload.last_name is not None:
+        user.last_name = payload.last_name.strip() or None
+    db.commit()
+    db.refresh(user)
+    return {
+        "id": user.id,
+        "email": user.email,
+        "first_name": user.first_name,
+        "last_name": user.last_name,
+    }
+
+
+@router.post("/subscription/cancel")
+async def cancel_subscription(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    sub = (
+        db.query(SubscriptionDB)
+        .filter(SubscriptionDB.user_id == current_user.id, SubscriptionDB.status == "active")
+        .order_by(SubscriptionDB.created_at.desc())
+        .first()
+    )
+    if not sub:
+        raise HTTPException(status_code=404, detail="Aucun abonnement actif à résilier.")
+
+    sub.status = "cancelled"
+    sub.canceled_at = datetime.utcnow()
+    db.commit()
+    db.refresh(sub)
+    return {
+        "status": "cancelled",
+        "message": "Ton abonnement ne sera pas renouvelé. Tu gardes l'accès jusqu'à sa date de fin.",
+        "end_date": sub.end_date,
+    }

--- a/backend/server.py
+++ b/backend/server.py
@@ -72,6 +72,10 @@ try:
 except ImportError:
     from backend.routes.trap_questions import router as trap_questions_router
 try:
+    from routes.profile import router as profile_router
+except ImportError:
+    from backend.routes.profile import router as profile_router
+try:
     from auth import get_current_user, get_current_user_optional
 except ImportError:
     from backend.auth import get_current_user, get_current_user_optional
@@ -133,6 +137,7 @@ app.include_router(admin_migration_router)
 app.include_router(mistakes_router)
 app.include_router(ai_coach_router)
 app.include_router(trap_questions_router)
+app.include_router(profile_router)
 
 
 # ===== Health Check Endpoint =====
@@ -639,12 +644,22 @@ async def register(user_in: UserCreate, db: Session = Depends(get_db)):
             detail="Email already registered"
         )
     
+    # Prénom / nom : champs dédiés, avec repli sur l'ancien "full_name"
+    first_name = (user_in.first_name or "").strip() or None
+    last_name = (user_in.last_name or "").strip() or None
+    if not first_name and not last_name and user_in.full_name:
+        parts = user_in.full_name.strip().split(" ", 1)
+        first_name = parts[0] or None
+        last_name = parts[1].strip() if len(parts) > 1 else None
+
     # Create new user
     user_id = str(uuid.uuid4())
     user = UserDB(
         id=user_id,
         email=user_in.email,
-        hashed_password=hash_password(user_in.password)
+        hashed_password=hash_password(user_in.password),
+        first_name=first_name,
+        last_name=last_name,
     )
     db.add(user)
     db.commit()

--- a/backend/tests/test_profile.py
+++ b/backend/tests/test_profile.py
@@ -1,0 +1,135 @@
+"""
+Tests du profil utilisateur : inscription avec prénom/nom, lecture du profil,
+modification du nom, et résiliation d'abonnement.
+"""
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+backend_path = Path(__file__).parent.parent
+sys.path.insert(0, str(backend_path))
+
+from server import app  # noqa: E402
+from database import Base, get_db  # noqa: E402
+from models import UserDB, SubscriptionDB, User  # noqa: E402
+from auth import get_current_user  # noqa: E402
+
+SQLALCHEMY_TEST_DATABASE_URL = "sqlite:///./test_profile.db"
+engine = create_engine(SQLALCHEMY_TEST_DATABASE_URL, connect_args={"check_same_thread": False})
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+TEST_USER = User(id="user-1", email="eleve@test.fr", first_name="Sarah", last_name="Cohen")
+
+
+def override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+client = TestClient(app)
+
+
+@pytest.fixture(scope="function")
+def db():
+    previous = dict(app.dependency_overrides)
+    app.dependency_overrides[get_db] = override_get_db
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    session.add(UserDB(id="user-1", email="eleve@test.fr", hashed_password="x",
+                       first_name="Sarah", last_name="Cohen"))
+    session.commit()
+    try:
+        yield session
+    finally:
+        session.close()
+        app.dependency_overrides = previous
+
+
+def test_register_stores_first_and_last_name(db):
+    r = client.post("/api/auth/register", json={
+        "email": "nouveau@test.fr", "password": "secret6",
+        "first_name": "David", "last_name": "Levy",
+    })
+    assert r.status_code == 200
+    user = db.query(UserDB).filter_by(email="nouveau@test.fr").first()
+    assert user.first_name == "David"
+    assert user.last_name == "Levy"
+
+
+def test_register_splits_full_name_fallback(db):
+    r = client.post("/api/auth/register", json={
+        "email": "compat@test.fr", "password": "secret6", "full_name": "Marie Dupont",
+    })
+    assert r.status_code == 200
+    user = db.query(UserDB).filter_by(email="compat@test.fr").first()
+    assert user.first_name == "Marie"
+    assert user.last_name == "Dupont"
+
+
+def test_get_profile(db):
+    app.dependency_overrides[get_current_user] = lambda: TEST_USER
+    try:
+        r = client.get("/api/profile")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["email"] == "eleve@test.fr"
+        assert body["first_name"] == "Sarah"
+        assert body["has_active_subscription"] is False
+        assert body["subscription"] is None
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
+def test_update_profile(db):
+    app.dependency_overrides[get_current_user] = lambda: TEST_USER
+    try:
+        r = client.patch("/api/profile", json={"first_name": "Sarah-Lea", "last_name": "Cohen-Levy"})
+        assert r.status_code == 200
+        assert r.json()["first_name"] == "Sarah-Lea"
+        user = db.query(UserDB).filter_by(id="user-1").first()
+        assert user.last_name == "Cohen-Levy"
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
+def test_profile_shows_active_subscription_and_cancel(db):
+    db.add(SubscriptionDB(
+        id="sub-1", user_id="user-1", plan_id="code_30d", status="active",
+        start_date=datetime.utcnow(), end_date=datetime.utcnow() + timedelta(days=30),
+    ))
+    db.commit()
+    app.dependency_overrides[get_current_user] = lambda: TEST_USER
+    try:
+        r = client.get("/api/profile")
+        body = r.json()
+        assert body["has_active_subscription"] is True
+        assert body["subscription"]["plan_id"] == "code_30d"
+        assert body["subscription"]["plan_name"]  # nom résolu depuis le catalogue
+
+        c = client.post("/api/profile/subscription/cancel")
+        assert c.status_code == 200
+        assert c.json()["status"] == "cancelled"
+
+        sub = db.query(SubscriptionDB).filter_by(id="sub-1").first()
+        assert sub.status == "cancelled"
+        assert sub.canceled_at is not None
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
+def test_cancel_without_subscription_404(db):
+    app.dependency_overrides[get_current_user] = lambda: TEST_USER
+    try:
+        r = client.post("/api/profile/subscription/cancel")
+        assert r.status_code == 404
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -9,6 +9,7 @@ import ExamDetails from "./pages/ExamDetails";
 import Training from "./pages/Training";
 import Mistakes from "./pages/Mistakes";
 import TrapQuestions from "./pages/TrapQuestions";
+import Profile from "./pages/Profile";
 import ChatWidget from "./components/ChatWidget";
 import Signs from "./pages/Signs";
 import Stats from "./pages/Stats";
@@ -104,6 +105,7 @@ function App() {
               <Route path="/training" element={<Training />} />
               <Route path="/mistakes" element={<Mistakes />} />
               <Route path="/questions-pieges" element={<TrapQuestions />} />
+              <Route path="/profile" element={<Profile />} />
               <Route path="/courses" element={<Courses />} />
               <Route path="/signs" element={<Signs />} />
               <Route path="/stats" element={<Stats />} />

--- a/frontend/src/context/AuthContext.js
+++ b/frontend/src/context/AuthContext.js
@@ -62,11 +62,12 @@ export const AuthProvider = ({ children }) => {
         return true;
     };
 
-    const register = async (email, password, fullName) => {
+    const register = async (email, password, firstName, lastName) => {
         await axios.post('/api/auth/register', {
             email,
             password,
-            full_name: fullName
+            first_name: firstName,
+            last_name: lastName,
         });
         return await login(email, password);
     };

--- a/frontend/src/pages/Dashboard.js
+++ b/frontend/src/pages/Dashboard.js
@@ -41,9 +41,16 @@ export default function Dashboard() {
             <header className="bg-white dark:bg-slate-800 border-b border-slate-200 dark:border-slate-700 sticky top-0 z-30 p-4">
                 <div className="max-w-5xl mx-auto flex justify-between items-center">
                     <h1 className="text-2xl font-heading font-bold text-slate-900 dark:text-white">Flash Neiga</h1>
-                    <div className="flex items-center gap-4">
-                        <span className="hidden md:inline-block font-medium text-sm text-slate-900 dark:text-white">{user?.full_name || user?.email}</span>
-                        <Button variant="ghost" size="icon" onClick={logout} data-testid="logout-btn">
+                    <div className="flex items-center gap-2 md:gap-3">
+                        <Link to="/profile" className="flex items-center gap-2 rounded-full px-2 py-1 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors" data-testid="profile-link" aria-label="Mon profil">
+                            <span className="h-8 w-8 rounded-full bg-sky-100 text-sky-700 dark:bg-sky-900/40 dark:text-sky-300 flex items-center justify-center">
+                                <User className="h-4 w-4" />
+                            </span>
+                            <span className="hidden md:inline-block font-medium text-sm text-slate-900 dark:text-white">
+                                {[user?.first_name, user?.last_name].filter(Boolean).join(' ') || user?.email}
+                            </span>
+                        </Link>
+                        <Button variant="ghost" size="icon" onClick={logout} data-testid="logout-btn" aria-label="Déconnexion">
                             <LogOut className="h-5 w-5" />
                         </Button>
                     </div>

--- a/frontend/src/pages/Profile.js
+++ b/frontend/src/pages/Profile.js
@@ -1,0 +1,212 @@
+import React, { useEffect, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import axios from 'axios';
+import { useAuth } from '../context/AuthContext';
+import { Button } from '../components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card';
+import { Input } from '../components/ui/input';
+import { Label } from '../components/ui/label';
+import { Badge } from '../components/ui/badge';
+import {
+    Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter,
+} from '../components/ui/dialog';
+import { ArrowLeft, User as UserIcon, Mail, CalendarDays, CreditCard, Save, LogOut, ArrowUpRight, Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
+
+const fmtDate = (d) => (d ? new Date(d).toLocaleDateString('fr-FR') : '—');
+
+export default function Profile() {
+    const { logout } = useAuth();
+    const navigate = useNavigate();
+    const [loading, setLoading] = useState(true);
+    const [profile, setProfile] = useState(null);
+    const [firstName, setFirstName] = useState('');
+    const [lastName, setLastName] = useState('');
+    const [saving, setSaving] = useState(false);
+    const [confirmCancel, setConfirmCancel] = useState(false);
+    const [cancelling, setCancelling] = useState(false);
+
+    const load = async () => {
+        setLoading(true);
+        try {
+            const res = await axios.get('/api/profile');
+            setProfile(res.data);
+            setFirstName(res.data.first_name || '');
+            setLastName(res.data.last_name || '');
+        } catch (e) {
+            toast.error('Impossible de charger ton profil.');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => { load(); }, []);
+
+    const saveName = async (e) => {
+        e.preventDefault();
+        setSaving(true);
+        try {
+            await axios.patch('/api/profile', { first_name: firstName, last_name: lastName });
+            toast.success('Profil mis à jour ✅');
+            setProfile((p) => ({ ...p, first_name: firstName, last_name: lastName }));
+        } catch (err) {
+            toast.error('La mise à jour a échoué.');
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const doCancel = async () => {
+        setCancelling(true);
+        try {
+            const res = await axios.post('/api/profile/subscription/cancel');
+            toast.success(res.data.message || 'Abonnement résilié.');
+            setConfirmCancel(false);
+            load();
+        } catch (err) {
+            toast.error(err.response?.data?.detail || 'La résiliation a échoué.');
+        } finally {
+            setCancelling(false);
+        }
+    };
+
+    const sub = profile?.subscription;
+
+    return (
+        <div className="min-h-screen pb-16">
+            <header className="bg-white dark:bg-slate-800 border-b border-slate-200 dark:border-slate-700 sticky top-0 z-30 p-4">
+                <div className="max-w-3xl mx-auto flex items-center justify-between">
+                    <div className="flex items-center gap-3">
+                        <Link to="/">
+                            <Button variant="ghost" size="icon" aria-label="Retour à l'accueil">
+                                <ArrowLeft className="h-5 w-5" />
+                            </Button>
+                        </Link>
+                        <h1 className="text-xl font-heading font-bold text-slate-900 dark:text-white">Mon profil</h1>
+                    </div>
+                    <Button variant="ghost" size="sm" onClick={logout} className="gap-2">
+                        <LogOut className="h-4 w-4" /> Déconnexion
+                    </Button>
+                </div>
+            </header>
+
+            <main className="max-w-3xl mx-auto p-4 space-y-6 mt-2">
+                {loading ? (
+                    <div className="py-16 text-center text-slate-600 dark:text-slate-300 flex items-center justify-center gap-2">
+                        <Loader2 className="h-5 w-5 animate-spin" /> Chargement…
+                    </div>
+                ) : (
+                    <>
+                        {/* Infos personnelles */}
+                        <Card className="bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-700">
+                            <CardHeader>
+                                <CardTitle className="flex items-center gap-2 text-slate-900 dark:text-white">
+                                    <UserIcon className="h-5 w-5 text-sky-600" /> Informations personnelles
+                                </CardTitle>
+                            </CardHeader>
+                            <CardContent>
+                                <form onSubmit={saveName} className="space-y-4">
+                                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                                        <div className="space-y-2">
+                                            <Label htmlFor="firstName">Prénom</Label>
+                                            <Input id="firstName" value={firstName} onChange={(e) => setFirstName(e.target.value)} placeholder="Ton prénom" />
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label htmlFor="lastName">Nom</Label>
+                                            <Input id="lastName" value={lastName} onChange={(e) => setLastName(e.target.value)} placeholder="Ton nom" />
+                                        </div>
+                                    </div>
+                                    <div className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+                                        <Mail className="h-4 w-4" /> {profile?.email}
+                                        <span className="text-xs text-slate-400">(l'email ne peut pas être modifié)</span>
+                                    </div>
+                                    <div className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+                                        <CalendarDays className="h-4 w-4" /> Membre depuis le {fmtDate(profile?.created_at)}
+                                    </div>
+                                    <Button type="submit" disabled={saving} className="gap-2">
+                                        {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
+                                        Enregistrer
+                                    </Button>
+                                </form>
+                            </CardContent>
+                        </Card>
+
+                        {/* Abonnement */}
+                        <Card className="bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-700">
+                            <CardHeader>
+                                <CardTitle className="flex items-center gap-2 text-slate-900 dark:text-white">
+                                    <CreditCard className="h-5 w-5 text-sky-600" /> Mon abonnement
+                                </CardTitle>
+                            </CardHeader>
+                            <CardContent className="space-y-4">
+                                {sub ? (
+                                    <>
+                                        <div className="flex flex-wrap items-center justify-between gap-3">
+                                            <div>
+                                                <div className="font-semibold text-slate-900 dark:text-white">{sub.plan_name}</div>
+                                                {sub.plan_description && (
+                                                    <div className="text-sm text-slate-600 dark:text-slate-300">{sub.plan_description}</div>
+                                                )}
+                                            </div>
+                                            {sub.is_active ? (
+                                                <Badge className="bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200 hover:bg-emerald-100">Actif</Badge>
+                                            ) : (
+                                                <Badge variant="secondary">{sub.status === 'cancelled' ? 'Résilié' : 'Inactif'}</Badge>
+                                            )}
+                                        </div>
+                                        <div className="grid grid-cols-2 gap-3 text-sm">
+                                            <div><span className="text-slate-500 dark:text-slate-400">Début : </span>{fmtDate(sub.start_date)}</div>
+                                            <div><span className="text-slate-500 dark:text-slate-400">Fin : </span>{fmtDate(sub.end_date)}</div>
+                                            {sub.amount != null && (
+                                                <div><span className="text-slate-500 dark:text-slate-400">Prix : </span>{sub.amount} {sub.currency}</div>
+                                            )}
+                                            {sub.canceled_at && (
+                                                <div><span className="text-slate-500 dark:text-slate-400">Résilié le : </span>{fmtDate(sub.canceled_at)}</div>
+                                            )}
+                                        </div>
+                                    </>
+                                ) : (
+                                    <p className="text-slate-600 dark:text-slate-300">Tu n'as pas d'abonnement actif pour le moment.</p>
+                                )}
+
+                                <div className="flex flex-wrap gap-3 pt-2">
+                                    <Link to="/pricing">
+                                        <Button className="gap-2">
+                                            <ArrowUpRight className="h-4 w-4" />
+                                            {sub && sub.is_active ? 'Changer / améliorer mon abonnement' : "Voir les abonnements"}
+                                        </Button>
+                                    </Link>
+                                    {sub && sub.is_active && (
+                                        <Button variant="outline" onClick={() => setConfirmCancel(true)} className="text-red-600 border-red-300 hover:bg-red-50 dark:hover:bg-red-950/30">
+                                            Résilier mon abonnement
+                                        </Button>
+                                    )}
+                                </div>
+                            </CardContent>
+                        </Card>
+                    </>
+                )}
+            </main>
+
+            {/* Confirmation de résiliation */}
+            <Dialog open={confirmCancel} onOpenChange={setConfirmCancel}>
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Résilier ton abonnement ?</DialogTitle>
+                        <DialogDescription>
+                            Ton abonnement ne sera pas renouvelé. Tu gardes l'accès à toutes les fonctionnalités
+                            jusqu'à la date de fin{sub?.end_date ? ` (${fmtDate(sub.end_date)})` : ''}.
+                        </DialogDescription>
+                    </DialogHeader>
+                    <DialogFooter className="gap-2">
+                        <Button variant="outline" onClick={() => setConfirmCancel(false)}>Annuler</Button>
+                        <Button variant="destructive" onClick={doCancel} disabled={cancelling} className="gap-2">
+                            {cancelling && <Loader2 className="h-4 w-4 animate-spin" />}
+                            Confirmer la résiliation
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+        </div>
+    );
+}

--- a/frontend/src/pages/Register.js
+++ b/frontend/src/pages/Register.js
@@ -11,7 +11,8 @@ import { toast } from 'sonner';
 export default function Register() {
     const [email, setEmail] = useState('');
     const [password, setPassword] = useState('');
-    const [fullName, setFullName] = useState('');
+    const [firstName, setFirstName] = useState('');
+    const [lastName, setLastName] = useState('');
     const [showPassword, setShowPassword] = useState(false);
     const { register } = useAuth();
     const navigate = useNavigate();
@@ -25,7 +26,7 @@ export default function Register() {
         }
         setIsLoading(true);
         try {
-            await register(email, password, fullName);
+            await register(email, password, firstName, lastName);
             toast.success("Compte créé avec succès !");
             navigate('/');
         } catch (error) {
@@ -49,19 +50,34 @@ export default function Register() {
                 </CardHeader>
                 <CardContent>
                     <form onSubmit={handleSubmit} className="space-y-4">
-                        <div className="space-y-2">
-                            <Label htmlFor="fullname">Nom complet</Label>
-                            <Input
-                                id="fullname"
-                                type="text"
-                                placeholder="Ex : Sarah Cohen"
-                                autoComplete="name"
-                                autoFocus
-                                value={fullName}
-                                onChange={(e) => setFullName(e.target.value)}
-                                required
-                                data-testid="register-name-input"
-                            />
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                            <div className="space-y-2">
+                                <Label htmlFor="firstname">Prénom</Label>
+                                <Input
+                                    id="firstname"
+                                    type="text"
+                                    placeholder="Ex : Sarah"
+                                    autoComplete="given-name"
+                                    autoFocus
+                                    value={firstName}
+                                    onChange={(e) => setFirstName(e.target.value)}
+                                    required
+                                    data-testid="register-firstname-input"
+                                />
+                            </div>
+                            <div className="space-y-2">
+                                <Label htmlFor="lastname">Nom</Label>
+                                <Input
+                                    id="lastname"
+                                    type="text"
+                                    placeholder="Ex : Cohen"
+                                    autoComplete="family-name"
+                                    value={lastName}
+                                    onChange={(e) => setLastName(e.target.value)}
+                                    required
+                                    data-testid="register-lastname-input"
+                                />
+                            </div>
                         </div>
                         <div className="space-y-2">
                             <Label htmlFor="email">Email</Label>
@@ -107,7 +123,7 @@ export default function Register() {
                         <Button
                             type="submit"
                             className="w-full"
-                            disabled={isLoading || !fullName || !email || !password}
+                            disabled={isLoading || !firstName || !lastName || !email || !password}
                             data-testid="register-submit-button"
                         >
                             {isLoading ? 'Création du compte…' : "Créer mon compte"}


### PR DESCRIPTION
…n, abonnement)

Backend :
- UserDB : colonnes first_name / last_name (+ migration ensure_schema_updated pour les bases existantes). UserCreate/User étendus ; get_current_user renvoie le nom.
- Inscription : stocke prénom/nom (repli en découpant l'ancien full_name).
- routes/profile.py : GET /api/profile (infos + abonnement courant résolu depuis le catalogue de plans), PATCH /api/profile (prénom/nom), POST /api/profile/subscription/cancel (résiliation : statut cancelled, accès conservé jusqu'à end_date).
- Tests : inscription avec noms, découpage full_name, lecture/màj profil, abonnement actif + résiliation (61 tests au vert).

Frontend :
- Inscription : champs Prénom + Nom séparés (au lieu de 'Nom complet').
- Nouvelle page Profile (/profile) : édition prénom/nom, email + date d'inscription, carte abonnement avec statut/dates/prix, boutons 'Changer / améliorer' (-> Tarifs) et 'Résilier' (avec confirmation).
- Dashboard : accès profil dans l'en-tête (avatar + nom cliquables).
- Design de base inchangé ; build front CI OK.


Claude-Session: https://claude.ai/code/session_0113q53FTZDxJhBTX1uVZiz9