### PR TITLE
Coach IA (Gemini), profil utilisateur, refonte Tarifs et améliorations UX

### DIFF
--- a/frontend/src/config/hypConfig.js
+++ b/frontend/src/config/hypConfig.js
@@ -4,6 +4,14 @@
 export const HYP_CONFIG = {
   backendUrl: process.env.REACT_APP_BACKEND_URL || '/api',
   plans: {
+    STANDARD: {
+      DAYS_14: 'standard_14d',
+      DAYS_30: 'standard_30d',
+    },
+    PREMIUM: {
+      DAYS_14: 'premium_14d',
+      DAYS_30: 'premium_30d',
+    },
     CODE: {
       DAYS_14: 'code_14d',
       DAYS_30: 'code_30d',
@@ -19,6 +27,10 @@ export const HYP_CONFIG = {
 };
 
 export const PLAN_DETAILS = {
+  standard_14d: { name: 'Formule Standard', price: 79, currency: 'ILS', duration: '14 jours' },
+  standard_30d: { name: 'Formule Standard', price: 129, currency: 'ILS', duration: '30 jours' },
+  premium_14d: { name: 'Formule Premium', price: 109, currency: 'ILS', duration: '14 jours' },
+  premium_30d: { name: 'Formule Premium', price: 159, currency: 'ILS', duration: '30 jours' },
   code_14d: {
     name: 'Code 14 jours',
     price: 99,

--- a/frontend/src/pages/Pricing.js
+++ b/frontend/src/pages/Pricing.js
@@ -1,304 +1,288 @@
 import React, { useState } from "react";
 import axios from "axios";
-import { HYP_CONFIG, PLAN_DETAILS, formatPrice } from '../config/hypConfig';
-import { Link } from "react-router-dom";
-import { Button } from "../components/ui/button";
+import { HYP_CONFIG } from '../config/hypConfig';
 import { useAuth } from "../context/AuthContext";
+import {
+  Zap, Crown, Target, Check, Star, ShieldCheck, Clock, Headphones, Bot, ArrowRight, Loader2,
+} from "lucide-react";
 
 async function startHypCheckout(planId, userEmail = null, userId = null) {
   try {
-    console.log('Starting HYP checkout for plan:', planId);
-
-    const body = {
-      plan_id: planId,
-      user_email: userEmail,
-      user_id: userId
-    };
-
-    const res = await axios.post('/api/payments/hyp/create-payment', body);
+    const res = await axios.post('/api/payments/hyp/create-payment', {
+      plan_id: planId, user_email: userEmail, user_id: userId,
+    });
     const paymentUrl = res.data?.payment_url;
-    
     if (paymentUrl) {
-      console.log('Redirecting to HYP payment URL:', paymentUrl);
       window.location.href = paymentUrl;
     } else {
-      alert('❌ Erreur: URL de paiement non disponible');
+      alert('❌ Erreur : URL de paiement non disponible');
     }
   } catch (e) {
-    console.error('HYP checkout error:', e?.response?.status, e?.response?.data);
     const errorDetail = e?.response?.data?.detail || 'Erreur inconnue';
-    alert(`❌ Erreur de paiement: ${errorDetail}`);
+    alert(`❌ Erreur de paiement : ${errorDetail}`);
   }
 }
 
-function Pricing() {
-  const [loading, setLoading] = useState(null);
-  const { user } = useAuth();
+const STANDARD_FEATURES = [
+  { text: "Questions officielles du Code de la route israélien" },
+  { text: "Correction automatique et immédiate" },
+  { text: "« Pourquoi ai-je fait cette erreur ? » — une explication claire apparaît après chaque mauvaise réponse pour comprendre et progresser" },
+  {
+    text: "Plateforme E-learning complète",
+    sub: [
+      "Cours de Code de la route",
+      "Fiches de révision",
+      "Explications illustrées",
+      "Préparation à l'examen théorique et aux leçons de conduite",
+    ],
+  },
+  { text: "Historique de toutes vos erreurs pour les retravailler jusqu'à leur parfaite maîtrise" },
+];
 
-  const handleCheckout = async (planId) => {
+const PREMIUM_FEATURES = [
+  { text: "Questions officielles du Code de la route israélien" },
+  { text: "Correction automatique et immédiate" },
+  { text: "Explication détaillée de chaque erreur" },
+  {
+    text: "Plateforme E-learning complète",
+    sub: [
+      "Cours de Code de la route",
+      "Fiches de révision",
+      "Explications illustrées",
+      "Préparation théorique et aux leçons de conduite",
+    ],
+  },
+  { text: "Suivi personnalisé de votre progression" },
+  { text: "Historique de toutes vos erreurs pour les retravailler jusqu'à leur parfaite maîtrise" },
+];
+
+const COACH_BULLETS = [
+  "Il t'explique chaque règle du Code de manière ultra simple",
+  "Des explications adaptées à ton niveau",
+  "Un coaching pour progresser plus vite",
+  "Il te fait comprendre facilement tes erreurs",
+];
+
+function FeatureItem({ item }) {
+  return (
+    <li className="flex flex-col gap-1">
+      <div className="flex items-start gap-2">
+        <Check className="h-4 w-4 mt-0.5 shrink-0 text-emerald-500" />
+        <span className="text-sm text-slate-700 dark:text-slate-200">{item.text}</span>
+      </div>
+      {item.sub && (
+        <ul className="ml-6 mt-1 space-y-1">
+          {item.sub.map((s, i) => (
+            <li key={i} className="flex items-start gap-2 text-xs text-slate-500 dark:text-slate-400">
+              <span className="mt-0.5">•</span><span>{s}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </li>
+  );
+}
+
+// Sélecteur de durée (14 / 30 jours) — deux options, une seule sélectionnée.
+function PriceOptions({ options, selected, onSelect, accent }) {
+  const ring = accent === 'gold' ? 'ring-yellow-400 border-yellow-400' : 'ring-sky-400 border-sky-400';
+  return (
+    <div className="grid grid-cols-2 gap-3">
+      {options.map((opt) => {
+        const isSel = selected === opt.planId;
+        return (
+          <button
+            key={opt.planId}
+            type="button"
+            onClick={() => onSelect(opt.planId)}
+            className={`rounded-xl border-2 p-3 text-center transition-all ${
+              isSel
+                ? `bg-white dark:bg-slate-900 ${ring} ring-2 shadow`
+                : 'border-slate-200 dark:border-slate-700 bg-white/70 dark:bg-slate-900/60 hover:border-slate-300'
+            }`}
+            aria-pressed={isSel}
+          >
+            <div className="text-2xl font-extrabold text-slate-900 dark:text-white">{opt.price} ₪</div>
+            <div className="text-xs text-slate-500 dark:text-slate-400">/ {opt.duration}</div>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function Pricing() {
+  const { user } = useAuth();
+  const [loading, setLoading] = useState(null);
+  const [standardSel, setStandardSel] = useState(HYP_CONFIG.plans.STANDARD.DAYS_30);
+  const [premiumSel, setPremiumSel] = useState(HYP_CONFIG.plans.PREMIUM.DAYS_30);
+
+  const checkout = async (planId) => {
     setLoading(planId);
     try {
-      // Pass the logged-in user's id/email so the subscription is linked to
-      // their account once the payment is confirmed by HYP.
       await startHypCheckout(planId, user?.email || null, user?.id || null);
     } finally {
       setLoading(null);
     }
   };
 
+  const standardOptions = [
+    { planId: HYP_CONFIG.plans.STANDARD.DAYS_14, price: 79, duration: '14 jours' },
+    { planId: HYP_CONFIG.plans.STANDARD.DAYS_30, price: 129, duration: '30 jours' },
+  ];
+  const premiumOptions = [
+    { planId: HYP_CONFIG.plans.PREMIUM.DAYS_14, price: 109, duration: '14 jours' },
+    { planId: HYP_CONFIG.plans.PREMIUM.DAYS_30, price: 159, duration: '30 jours' },
+  ];
+
   return (
-    <div className="p-6 max-w-6xl mx-auto">
-      <h1 className="text-3xl font-bold mb-6 text-center text-slate-900 dark:text-white">Abonnements Flash Neiga</h1>
+    <div className="min-h-screen bg-[#0c1a2e] text-white relative overflow-hidden">
+      {/* Accents lumineux d'arrière-plan (cohérents avec le reste du site) */}
+      <div className="pointer-events-none absolute inset-0 overflow-hidden">
+        <div className="absolute -top-24 -left-24 w-96 h-96 rounded-full bg-sky-500/10 blur-3xl" />
+        <div className="absolute bottom-0 -right-24 w-96 h-96 rounded-full bg-yellow-400/10 blur-3xl" />
+      </div>
 
-      <div className="grid md:grid-cols-2 gap-6 mb-6">
-        {/* Code Subscription Card */}
-        <div className="rounded-lg border-2 border-blue-300 dark:border-blue-600 p-6 bg-white dark:bg-slate-800 shadow-lg">
-          <h2 className="text-2xl font-bold mb-3 text-blue-700 dark:text-blue-400">📚 Abonnement au Code</h2>
-          <ul className="list-disc pl-5 space-y-2 mb-4 text-sm text-slate-700 dark:text-slate-200">
-            <li>Accès à la Web App</li>
-            <li>Livre de code en ligne (E-book)</li>
-            <li>Questions officielles du code israélien</li>
-            <li>Examens blancs</li>
-            <li>Coaching / cours privés de code</li>
-          </ul>
-          
-          <div className="space-y-3">
-            <div className="p-3 bg-slate-50 dark:bg-slate-700 rounded">
-              <div className="font-semibold text-lg text-slate-900 dark:text-white">
-                14 jours - {formatPrice(PLAN_DETAILS.code_14d.price)}
-              </div>
-              <Button 
-                variant="outline" 
-                className="w-full mt-2" 
-                onClick={() => handleCheckout(HYP_CONFIG.plans.CODE.DAYS_14)}
-                disabled={loading === HYP_CONFIG.plans.CODE.DAYS_14}
-              >
-                {loading === HYP_CONFIG.plans.CODE.DAYS_14 ? 'Chargement...' : 'Souscrire 14 jours'}
-              </Button>
+      <div className="relative z-10 max-w-5xl mx-auto px-4 py-6">
+        {/* Barre de marque */}
+        <div className="flex items-center justify-between mb-8">
+          <div className="flex items-center gap-3">
+            <div className="h-10 w-10 rounded-xl bg-yellow-400 flex items-center justify-center shadow-lg shadow-yellow-400/30">
+              <Zap className="h-5 w-5 text-slate-900" />
             </div>
-            
-            <div className="p-3 bg-blue-50 dark:bg-blue-950/30 rounded border-2 border-blue-300 dark:border-blue-600">
-              <div className="flex items-center justify-between">
-                <div>
-                  <span className="font-semibold text-lg text-slate-900 dark:text-white">
-                    30 jours - {formatPrice(PLAN_DETAILS.code_30d.price)}
-                  </span>
-                  {PLAN_DETAILS.code_30d.originalPrice && (
-                    <span className="ml-2 line-through opacity-60 text-sm text-slate-600 dark:text-slate-400">
-                      {formatPrice(PLAN_DETAILS.code_30d.originalPrice)}
-                    </span>
-                  )}
-                </div>
-                {PLAN_DETAILS.code_30d.discount && (
-                  <span className="bg-blue-600 text-white px-2 py-1 rounded text-xs font-bold">
-                    {PLAN_DETAILS.code_30d.discount}
-                  </span>
-                )}
-              </div>
-              <Button 
-                variant="default" 
-                className="w-full mt-2 bg-blue-600 hover:bg-blue-700" 
-                onClick={() => handleCheckout(HYP_CONFIG.plans.CODE.DAYS_30)}
-                disabled={loading === HYP_CONFIG.plans.CODE.DAYS_30}
-              >
-                {loading === HYP_CONFIG.plans.CODE.DAYS_30 ? 'Chargement...' : 'Souscrire 30 jours'}
-              </Button>
+            <div className="leading-tight">
+              <div className="text-sm font-bold tracking-wide text-white/90">בריין טרטור</div>
+              <div className="text-xs text-yellow-300 font-semibold">Flashneiga</div>
             </div>
-            
-            <div className="p-3 bg-gray-50 dark:bg-gray-800 rounded">
-              <div className="font-semibold text-slate-900 dark:text-white">
-                Extension hebdomadaire - {formatPrice(PLAN_DETAILS.code_ext.price)}
+          </div>
+          <a href="#plans" className="rounded-full bg-yellow-400 text-slate-900 font-bold text-sm px-5 py-2 shadow-lg shadow-yellow-400/30 hover:bg-yellow-300 transition-colors">
+            Commencer
+          </a>
+        </div>
+
+        {/* Hero */}
+        <div className="text-center max-w-2xl mx-auto mb-8">
+          <h1 className="text-3xl md:text-4xl font-extrabold leading-tight">
+            Choisissez la formule<br />
+            <span className="text-yellow-400">qui vous correspond</span>
+          </h1>
+          <p className="mt-3 text-sm md:text-base text-white/70">
+            Réussissez votre Code de la route israélien du 1er coup grâce à une méthode moderne, interactive et efficace.
+          </p>
+        </div>
+
+        {/* Bandeau 95% */}
+        <div className="mb-10 rounded-2xl bg-gradient-to-r from-yellow-400 to-amber-400 text-slate-900 p-4 flex items-start gap-3 shadow-lg shadow-yellow-400/20 max-w-3xl mx-auto">
+          <div className="h-9 w-9 rounded-full bg-slate-900/10 flex items-center justify-center shrink-0">
+            <Target className="h-5 w-5 text-slate-900" />
+          </div>
+          <p className="text-sm font-medium">
+            Plus de <strong>95 %</strong> de nos élèves réussissent grâce à une méthode basée sur la compréhension, et non sur le simple apprentissage par cœur.
+          </p>
+        </div>
+
+        {/* Cartes */}
+        <div id="plans" className="grid md:grid-cols-2 gap-6 items-start">
+
+          {/* Formule Standard */}
+          <div className="rounded-3xl bg-white dark:bg-slate-800 text-slate-900 dark:text-white p-6 shadow-xl border border-white/10">
+            <div className="flex items-center gap-3 mb-4">
+              <div className="h-11 w-11 rounded-2xl bg-sky-100 text-sky-600 flex items-center justify-center">
+                <Zap className="h-6 w-6" />
               </div>
-              <Button 
-                variant="outline" 
-                size="sm"
-                className="w-full mt-2" 
-                onClick={() => handleCheckout(HYP_CONFIG.plans.CODE.EXTENSION)}
-                disabled={loading === HYP_CONFIG.plans.CODE.EXTENSION}
-              >
-                {loading === HYP_CONFIG.plans.CODE.EXTENSION ? 'Chargement...' : 'Prolonger d\'une semaine'}
-              </Button>
+              <h2 className="text-xl font-extrabold">Formule Standard</h2>
             </div>
+
+            <PriceOptions options={standardOptions} selected={standardSel} onSelect={setStandardSel} accent="sky" />
+
+            <div className="mt-5">
+              <div className="text-sm font-bold text-slate-900 dark:text-white mb-2">Inclus :</div>
+              <ul className="space-y-3">
+                {STANDARD_FEATURES.map((f, i) => <FeatureItem key={i} item={f} />)}
+              </ul>
+            </div>
+
+            <button
+              onClick={() => checkout(standardSel)}
+              disabled={loading === standardSel}
+              className="mt-6 w-full rounded-xl bg-sky-500 hover:bg-sky-600 text-white font-bold py-3 uppercase tracking-wide transition-colors flex items-center justify-center gap-2 disabled:opacity-60"
+            >
+              {loading === standardSel ? <Loader2 className="h-5 w-5 animate-spin" /> : <>Commencer <ArrowRight className="h-4 w-4" /></>}
+            </button>
+          </div>
+
+          {/* Formule Premium */}
+          <div className="relative rounded-3xl bg-white dark:bg-slate-800 text-slate-900 dark:text-white p-6 shadow-2xl border-2 border-yellow-400">
+            {/* Ruban */}
+            <div className="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-yellow-400 text-slate-900 text-xs font-bold px-4 py-1 flex items-center gap-1 shadow">
+              <Star className="h-3.5 w-3.5 fill-slate-900" /> LA FORMULE LA PLUS CHOISIE
+            </div>
+
+            <div className="flex items-center gap-3 mb-4 mt-2">
+              <div className="h-11 w-11 rounded-2xl bg-yellow-100 text-yellow-600 flex items-center justify-center">
+                <Crown className="h-6 w-6" />
+              </div>
+              <h2 className="text-xl font-extrabold">Formule Premium</h2>
+            </div>
+
+            <PriceOptions options={premiumOptions} selected={premiumSel} onSelect={setPremiumSel} accent="gold" />
+
+            <div className="mt-5">
+              <div className="text-sm font-bold text-slate-900 dark:text-white mb-2">Tout le contenu de la Formule Standard</div>
+              <ul className="space-y-3">
+                {PREMIUM_FEATURES.map((f, i) => <FeatureItem key={i} item={f} />)}
+              </ul>
+            </div>
+
+            {/* Bonus Coach IA */}
+            <div className="mt-5 rounded-2xl bg-[#0c1a2e] text-white p-4">
+              <div className="inline-flex items-center gap-1 rounded-full bg-yellow-400 text-slate-900 text-[11px] font-bold px-2.5 py-0.5 mb-2">
+                <Bot className="h-3.5 w-3.5" /> BONUS COACH IA
+              </div>
+              <div className="font-bold text-lg">Votre Coach IA personnel</div>
+              <p className="text-sm text-white/80 mt-1">
+                Un véritable prof pédagogique disponible <strong>24h/24 et 7j/7</strong>. Pose-lui toutes tes questions à toute heure, il te répond instantanément.
+              </p>
+              <ul className="mt-3 space-y-1.5">
+                {COACH_BULLETS.map((b, i) => (
+                  <li key={i} className="flex items-start gap-2 text-sm text-white/90">
+                    <Check className="h-4 w-4 mt-0.5 shrink-0 text-yellow-400" /> {b}
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            <button
+              onClick={() => checkout(premiumSel)}
+              disabled={loading === premiumSel}
+              className="mt-6 w-full rounded-xl bg-yellow-400 hover:bg-yellow-300 text-slate-900 font-bold py-3 uppercase tracking-wide transition-colors flex items-center justify-center gap-2 disabled:opacity-60"
+            >
+              {loading === premiumSel ? <Loader2 className="h-5 w-5 animate-spin" /> : <>Choisir Premium <ArrowRight className="h-4 w-4" /></>}
+            </button>
           </div>
         </div>
 
-        {/* Videos Subscription Card */}
-        <div className="rounded-lg border-2 border-purple-300 dark:border-purple-600 p-6 bg-white dark:bg-slate-800 shadow-lg">
-          <h2 className="text-2xl font-bold mb-3 text-purple-700 dark:text-purple-400">🎥 Vidéos Pédagogiques</h2>
-          <p className="mb-4 text-sm text-slate-600 dark:text-slate-300">
-            Vidéos sur les 28 objectifs dans l'apprentissage de la conduite + 
-            parcours examens filmés et commentés + situations réelles à anticiper 
-            en format "Conduite Commentée"
-          </p>
-          
-          <div className="space-y-3">
-            <div className="p-3 bg-slate-50 dark:bg-slate-700 rounded">
-              <div className="font-semibold text-lg text-slate-900 dark:text-white">
-                1 mois - {formatPrice(PLAN_DETAILS.video_1m.price)}
-              </div>
-              <Button 
-                variant="outline" 
-                className="w-full mt-2" 
-                onClick={() => handleCheckout(HYP_CONFIG.plans.VIDEO.MONTH_1)}
-                disabled={loading === HYP_CONFIG.plans.VIDEO.MONTH_1}
-              >
-                {loading === HYP_CONFIG.plans.VIDEO.MONTH_1 ? 'Chargement...' : 'Souscrire 1 mois'}
-              </Button>
-            </div>
-            
-            <div className="p-3 bg-purple-50 dark:bg-purple-950/30 rounded border-2 border-purple-300 dark:border-purple-600">
-              <div className="flex items-center justify-between">
-                <div>
-                  <span className="font-semibold text-lg text-slate-900 dark:text-white">
-                    2 mois - {formatPrice(PLAN_DETAILS.video_2m.price)}
-                  </span>
-                  {PLAN_DETAILS.video_2m.originalPrice && (
-                    <span className="ml-2 line-through opacity-60 text-sm text-slate-600 dark:text-slate-400">
-                      {formatPrice(PLAN_DETAILS.video_2m.originalPrice)}
-                    </span>
-                  )}
-                </div>
-                {PLAN_DETAILS.video_2m.discount && (
-                  <span className="bg-purple-600 text-white px-2 py-1 rounded text-xs font-bold">
-                    {PLAN_DETAILS.video_2m.discount}
-                  </span>
-                )}
-              </div>
-              <Button 
-                variant="default" 
-                className="w-full mt-2 bg-purple-600 hover:bg-purple-700" 
-                onClick={() => handleCheckout(HYP_CONFIG.plans.VIDEO.MONTH_2)}
-                disabled={loading === HYP_CONFIG.plans.VIDEO.MONTH_2}
-              >
-                {loading === HYP_CONFIG.plans.VIDEO.MONTH_2 ? 'Chargement...' : 'Souscrire 2 mois'}
-              </Button>
-            </div>
-            
-            <div className="p-3 bg-purple-100 dark:bg-purple-900/30 rounded border-2 border-purple-400 dark:border-purple-500">
-              <div className="flex items-center justify-between">
-                <div>
-                  <span className="font-semibold text-lg text-slate-900 dark:text-white">
-                    3 mois - {formatPrice(PLAN_DETAILS.video_3m.price)}
-                  </span>
-                  {PLAN_DETAILS.video_3m.originalPrice && (
-                    <span className="ml-2 line-through opacity-60 text-sm text-slate-600 dark:text-slate-400">
-                      {formatPrice(PLAN_DETAILS.video_3m.originalPrice)}
-                    </span>
-                  )}
-                </div>
-                {PLAN_DETAILS.video_3m.discount && (
-                  <span className="bg-purple-700 text-white px-2 py-1 rounded text-xs font-bold">
-                    {PLAN_DETAILS.video_3m.discount}
-                  </span>
-                )}
-              </div>
-              <Button 
-                variant="default" 
-                className="w-full mt-2 bg-purple-700 hover:bg-purple-800" 
-                onClick={() => handleCheckout(HYP_CONFIG.plans.VIDEO.MONTH_3)}
-                disabled={loading === HYP_CONFIG.plans.VIDEO.MONTH_3}
-              >
-                {loading === HYP_CONFIG.plans.VIDEO.MONTH_3 ? 'Chargement...' : 'Souscrire 3 mois'}
-              </Button>
-            </div>
-            
-            <div className="p-3 bg-gray-50 dark:bg-gray-800 rounded">
-              <div className="font-semibold text-slate-900 dark:text-white">
-                Extension hebdomadaire - {formatPrice(PLAN_DETAILS.video_ext.price)}
-              </div>
-              <Button 
-                variant="outline" 
-                size="sm"
-                className="w-full mt-2" 
-                onClick={() => handleCheckout(HYP_CONFIG.plans.VIDEO.EXTENSION)}
-                disabled={loading === HYP_CONFIG.plans.VIDEO.EXTENSION}
-              >
-                {loading === HYP_CONFIG.plans.VIDEO.EXTENSION ? 'Chargement...' : 'Prolonger d\'une semaine'}
-              </Button>
-            </div>
+        {/* Réassurance */}
+        <div className="mt-10 grid grid-cols-1 sm:grid-cols-3 gap-4 text-center">
+          <div className="flex flex-col items-center gap-1 text-white/80">
+            <ShieldCheck className="h-6 w-6 text-yellow-400" />
+            <span className="text-sm font-medium">Paiement 100 % sécurisé</span>
+          </div>
+          <div className="flex flex-col items-center gap-1 text-white/80">
+            <Clock className="h-6 w-6 text-yellow-400" />
+            <span className="text-sm font-medium">Accès immédiat après paiement</span>
+          </div>
+          <div className="flex flex-col items-center gap-1 text-white/80">
+            <Headphones className="h-6 w-6 text-yellow-400" />
+            <span className="text-sm font-medium">Support réactif garanti</span>
           </div>
         </div>
-      </div>
 
-      {/* Combo Offer Section */}
-      <div className="rounded-lg border-2 border-green-300 dark:border-green-600 p-6 bg-gradient-to-r from-green-50 to-yellow-50 dark:from-green-950/30 dark:to-yellow-950/30 shadow-lg">
-        <div className="flex items-center gap-2 mb-3">
-          <span className="text-3xl">🎁</span>
-          <h2 className="text-2xl font-bold text-green-800 dark:text-green-300">Offre Combinée - 2 Leçons Offertes!</h2>
+        <div className="mt-8 text-center">
+          <a href="/login" className="text-sm text-white/60 hover:text-white underline underline-offset-4">
+            J'ai déjà un compte — me connecter
+          </a>
         </div>
-        
-        <div className="bg-white dark:bg-slate-800 rounded p-4 mb-4 border border-slate-200 dark:border-slate-700">
-          <p className="font-semibold text-lg mb-2 text-green-700 dark:text-green-400">
-            Valeur: 390₪ - 420₪
-          </p>
-          <p className="text-slate-700 dark:text-slate-200 mb-2">
-            <strong>Comment en bénéficier:</strong>
-          </p>
-          <ul className="list-disc pl-5 space-y-1 text-sm text-slate-600 dark:text-slate-300">
-            <li>Souscrivez au <strong>Code</strong> ET aux <strong>Vidéos 3 mois</strong></li>
-            <li>OU si vous avez déjà le code, souscrivez aux <strong>Vidéos 3 mois</strong></li>
-          </ul>
-        </div>
-        
-        <div className="bg-yellow-100 dark:bg-yellow-900/30 border-l-4 border-yellow-500 dark:border-yellow-400 p-4 rounded">
-          <p className="text-sm text-slate-700 dark:text-slate-200">
-            ℹ️ Le bonus de 2 leçons de conduite offertes sera automatiquement enregistré 
-            lors de votre souscription aux Vidéos 3 mois si vous êtes éligible.
-          </p>
-        </div>
-      </div>
-
-      {/* Pricing Summary Table */}
-      <div className="mt-8 overflow-x-auto">
-        <h3 className="text-xl font-bold mb-4 text-slate-900 dark:text-white">📋 Tableau récapitulatif des prix</h3>
-        <table className="min-w-full bg-white dark:bg-slate-800 border border-slate-300 dark:border-slate-600 rounded-lg">
-          <thead className="bg-slate-100 dark:bg-slate-700">
-            <tr>
-              <th className="px-4 py-2 text-left border border-slate-300 dark:border-slate-600 text-slate-900 dark:text-white">Offre</th>
-              <th className="px-4 py-2 text-left border border-slate-300 dark:border-slate-600 text-slate-900 dark:text-white">Prix</th>
-              <th className="px-4 py-2 text-left border border-slate-300 dark:border-slate-600 text-slate-900 dark:text-white">Prix barré</th>
-              <th className="px-4 py-2 text-left border border-slate-300 dark:border-slate-600 text-slate-900 dark:text-white">Réduction</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td className="px-4 py-2 border border-slate-300 dark:border-slate-600 text-slate-900 dark:text-white">Code 14 jours</td>
-              <td className="px-4 py-2 border border-slate-300 dark:border-slate-600 font-semibold text-slate-900 dark:text-white">119₪</td>
-              <td className="px-4 py-2 border border-slate-300 dark:border-slate-600 text-slate-900 dark:text-white">-</td>
-              <td className="px-4 py-2 border border-slate-300 dark:border-slate-600 text-slate-900 dark:text-white">-</td>
-            </tr>
-            <tr className="bg-blue-50 dark:bg-blue-950/30">
-              <td className="px-4 py-2 border border-slate-300 dark:border-slate-600 text-slate-900 dark:text-white">Code 30 jours</td>
-              <td className="px-4 py-2 border border-slate-300 dark:border-slate-600 font-semibold text-slate-900 dark:text-white">189₪</td>
-              <td className="px-4 py-2 border border-slate-300 dark:border-slate-600 line-through text-slate-600 dark:text-slate-400">238₪</td>
-              <td className="px-4 py-2 border border-slate-300 dark:border-slate-600 text-blue-600 dark:text-blue-400 font-bold">-21%</td>
-            </tr>
-            <tr>
-              <td className="px-4 py-2 border border-slate-300 dark:border-slate-600 text-slate-900 dark:text-white">Vidéos 1 mois</td>
-              <td className="px-4 py-2 border border-slate-300 dark:border-slate-600 font-semibold text-slate-900 dark:text-white">199₪</td>
-              <td className="px-4 py-2 border border-slate-300 dark:border-slate-600 text-slate-900 dark:text-white">-</td>
-              <td className="px-4 py-2 border border-slate-300 dark:border-slate-600 text-slate-900 dark:text-white">-</td>
-            </tr>
-            <tr className="bg-purple-50 dark:bg-purple-950/30">
-              <td className="px-4 py-2 border border-slate-300 dark:border-slate-600 text-slate-900 dark:text-white">Vidéos 2 mois</td>
-              <td className="px-4 py-2 border border-slate-300 dark:border-slate-600 font-semibold text-slate-900 dark:text-white">349₪</td>
-              <td className="px-4 py-2 border border-slate-300 dark:border-slate-600 line-through text-slate-600 dark:text-slate-400">398₪</td>
-              <td className="px-4 py-2 border border-slate-300 dark:border-slate-600 text-purple-600 dark:text-purple-400 font-bold">-12%</td>
-            </tr>
-            <tr className="bg-purple-100 dark:bg-purple-900/30">
-              <td className="px-4 py-2 border border-slate-300 dark:border-slate-600 text-slate-900 dark:text-white">Vidéos 3 mois</td>
-              <td className="px-4 py-2 border border-slate-300 dark:border-slate-600 font-semibold text-slate-900 dark:text-white">489₪</td>
-              <td className="px-4 py-2 border border-slate-300 dark:border-slate-600 line-through text-slate-600 dark:text-slate-400">597₪</td>
-              <td className="px-4 py-2 border border-slate-300 dark:border-slate-600 text-purple-700 dark:text-purple-300 font-bold">-18%</td>
-            </tr>
-            <tr>
-              <td className="px-4 py-2 border border-slate-300 dark:border-slate-600 text-slate-900 dark:text-white">Extension 1 semaine</td>
-              <td className="px-4 py-2 border border-slate-300 dark:border-slate-600 font-semibold text-slate-900 dark:text-white">49₪</td>
-              <td className="px-4 py-2 border border-slate-300 dark:border-slate-600 text-slate-900 dark:text-white">-</td>
-              <td className="px-4 py-2 border border-slate-300 dark:border-slate-600 text-slate-900 dark:text-white">-</td>
-            </tr>
-          </tbody>
-        </table>
       </div>
     </div>
   );

--- a/hyp_plans.json
+++ b/hyp_plans.json
@@ -1,4 +1,36 @@
 {
+  "standard_14d": {
+    "name": "Formule Standard — 14 jours",
+    "description": "Questions officielles, correction immédiate, explications après chaque erreur, plateforme e-learning complète, historique des erreurs à retravailler.",
+    "amount": 79,
+    "currency": "ILS",
+    "duration_days": 14,
+    "type": "standard"
+  },
+  "standard_30d": {
+    "name": "Formule Standard — 30 jours",
+    "description": "Questions officielles, correction immédiate, explications après chaque erreur, plateforme e-learning complète, historique des erreurs à retravailler.",
+    "amount": 129,
+    "currency": "ILS",
+    "duration_days": 30,
+    "type": "standard"
+  },
+  "premium_14d": {
+    "name": "Formule Premium — 14 jours",
+    "description": "Tout le contenu Standard + suivi personnalisé + Coach IA personnel disponible 24h/24 et 7j/7.",
+    "amount": 109,
+    "currency": "ILS",
+    "duration_days": 14,
+    "type": "premium"
+  },
+  "premium_30d": {
+    "name": "Formule Premium — 30 jours",
+    "description": "Tout le contenu Standard + suivi personnalisé + Coach IA personnel disponible 24h/24 et 7j/7.",
+    "amount": 159,
+    "currency": "ILS",
+    "duration_days": 30,
+    "type": "premium"
+  },
   "code_14d": {
     "name": "Abonnement Code 14 jours",
     "description": "Accès Web App, E-book, Questions officielles, Examens blancs, Coaching",


### PR DESCRIPTION
## Résumé

Cette PR ajoute un **coach IA pédagogique** propulsé par **Google Gemini** au site d'entraînement au code de la route israélien, un **profil utilisateur** complet, une **refonte de la page Tarifs**, et de nombreuses améliorations **UX** — le tout sans changer le design de base (couleurs, composants).

## Fonctionnalités IA (Gemini 2.5 Flash)

- **Mini-leçon sur réponse fausse** — bouton « 📚 Petite leçon de code sur ce sujet » dans l'entraînement, la revue d'examen, les questions à retravailler et les questions pièges. Explication claire, rappel de la règle israélienne, erreurs à éviter. Mise en cache en base (`ai_lessons`) → réutilisée pour tous les élèves.
- **Rubrique « Mes questions à retravailler »** — chaque erreur (entraînement + examen) est mémorisée ; 2 bonnes réponses consécutives en révision la font sortir.
- **Bilan de série** après un examen — notions maîtrisées / à retravailler (avec lien vers les cours réels), mini-cours par erreur, et **encouragement chiffré calculé en SQL** (progression semaine vs semaine).
- **Questions pièges les plus fréquentes** — agrégation tous élèves + synthèse pédagogique régénérable par l'admin.
- **Chatbot « prof 24h/24 »** — bulle flottante sur tout le site + **discussions contextuelles** intégrées aux leçons et aux cours.

### Couche IA
- Client partagé `ai_client.py` : SDK officiel `google-genai`, JSON structuré natif (`response_schema`), thinking désactivé, parsing robuste. Fournisseur Claude conservé en option (`AI_PROVIDER=claude`).
- Repli propre : si l'IA est indisponible, le site continue de fonctionner (503 côté blocs IA uniquement).
- Endpoints de diagnostic `GET /api/ai-coach/health` et `/selftest`.

## Profil utilisateur

- Inscription avec **prénom + nom** (nouvelles colonnes `first_name` / `last_name`, migration automatique).
- Page **/profile** : édition du nom, email + date d'inscription, carte **abonnement** (statut, dates, prix) avec **résiliation** et **passage à un abonnement supérieur** (→ Tarifs).

## Page Tarifs (refonte selon maquette)

- Formules **Standard** (79 ₪ / 14 j · 129 ₪ / 30 j) et **Premium** (109 ₪ / 14 j · 159 ₪ / 30 j).
- Fond navy + accents jaunes, bandeau « 95 % de réussite », carte Premium mise en avant avec **encadré Coach IA 24/7**, sélecteur de durée, responsive. Flux de paiement HYP inchangé.

## Améliorations UX (sans changer le design)

- **Bouton retour accueil** sur Entraînement, Panneaux et Statistiques.
- Refonte des contrôles de l'Entraînement (recherche + catégories aérées et responsives), compteur « Question X sur Y », Entrée = suivante.
- Compteur « X/Y répondues » en examen.
- Connexion/Inscription : afficher/masquer le mot de passe, autofocus/autocomplete, validation, libellés plus clairs.
- Correction d'un bug latent qui plantait l'état vide de l'entraînement.

## Documentation

- `docs/PROMPT_AI_COACH.md`, `docs/PRICING_IA_GEMINI.md` et un **dossier PDF de pricing IA** (16 pages).

## Tests & vérification

- **61 tests backend au vert** (mémoire des erreurs, règle de maîtrise, cache des leçons, encouragement SQL, agrégation pièges, profil/résiliation, couche IA).
- Build frontend de production `CI=true` propre à chaque étape.

## Configuration requise (déploiement)

Variables d'environnement backend (Render) : `AI_PROVIDER=gemini`, `GEMINI_MODEL`, `GEMINI_API_KEY` (clé Google AI Studio) — ou config Vertex. Passer en **Tier 1** (facturation liée) + plafond mensuel pour la production.

## Points ouverts / à confirmer

- Résiliation : marque l'abonnement résilié côté application (accès jusqu'à `end_date`) ; à brancher sur HYP si un jour les plans deviennent auto-renouvelés.
- Bilan de série pour l'**entraînement libre** (≥ 10 questions) pas encore branché (fonctionne pour les examens).
- Couleurs exactes des cartes Tarifs à valider (fond blanc + accent vs fond bleu plein).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0113q53FTZDxJhBTX1uVZiz9)_