### PR TITLE
Corrige l'échec de build Netlify sur la page CRM

### DIFF
--- a/frontend/src/pages/AdminCRM.js
+++ b/frontend/src/pages/AdminCRM.js
@@ -99,11 +99,14 @@ export default function AdminCRM() {
         }
     }, [handleError]);
 
-    const fetchUsers = useCallback(async (nextOffset = 0) => {
+    // Les critères sont passés en arguments (et non lus dans la closure) pour que
+    // ce chargeur reste stable : le premier chargement ne se relance pas à chaque
+    // frappe dans le champ de recherche.
+    const loadUsers = useCallback(async (nextOffset, searchTerm, status) => {
         setUsersLoading(true);
         try {
             const { data } = await axios.get('/api/admin/crm/users', {
-                params: { search: search || undefined, status: statusFilter, limit: LIMIT, offset: nextOffset },
+                params: { search: searchTerm || undefined, status, limit: LIMIT, offset: nextOffset },
             });
             setUsers(data.items || []);
             setUsersTotal(data.total || 0);
@@ -114,7 +117,21 @@ export default function AdminCRM() {
         } finally {
             setUsersLoading(false);
         }
-    }, [search, statusFilter, handleError]);
+    }, [handleError]);
+
+    const fetchUsers = useCallback(
+        (nextOffset = 0) => loadUsers(nextOffset, search, statusFilter),
+        [loadUsers, search, statusFilter],
+    );
+
+    const loadPlans = useCallback(async () => {
+        try {
+            const { data } = await axios.get('/api/admin/crm/plans');
+            setPlans(data.plans || []);
+        } catch {
+            /* le sélecteur reste vide : non bloquant */
+        }
+    }, []);
 
     const fetchTransactions = useCallback(async () => {
         setTxLoading(true);
@@ -130,12 +147,9 @@ export default function AdminCRM() {
 
     useEffect(() => {
         fetchStats();
-        fetchUsers(0);
-        axios.get('/api/admin/crm/plans')
-            .then(({ data }) => setPlans(data.plans || []))
-            .catch(() => { /* le sélecteur reste vide, non bloquant */ });
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
+        loadUsers(0, '', 'all');
+        loadPlans();
+    }, [fetchStats, loadUsers, loadPlans]);
 
     const openUser = async (userId) => {
         setDetailLoading(true);


### PR DESCRIPTION
Le commentaire `eslint-disable-next-line react-hooks/exhaustive-deps` faisait échouer `craco build` : le plugin react-hooks n'est pas chargé dans la config ESLint utilisée au build, et une directive visant une règle inconnue est remontée en erreur (bloquante avec CI=true sur Netlify).

Plutôt que de désactiver une règle, le chargement initial n'en a plus besoin : `loadUsers` reçoit désormais ses critères en arguments au lieu de les lire dans la closure, ce qui le rend stable. L'effet de montage peut donc déclarer toutes ses dépendances, et la recherche ne relance plus le premier chargement à chaque frappe. `loadPlans` est extrait de la même façon.

Build vérifié en local avec CI=true : « Compiled successfully ».


Claude-Session: https://claude.ai/code/session_01XXGNQpQ1pYp4iw2e7tLtDg