### PR TITLE
Compte obligatoire avant paiement, et rattrapage des paiements orphelins

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -2,8 +2,11 @@
 Authentication utilities for Flash Neiga API
 Extracted to avoid circular imports
 """
+from datetime import datetime, timedelta, timezone
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from passlib.context import CryptContext
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 from jose import JWTError, jwt
 from typing import Optional
@@ -21,6 +24,67 @@ SECRET_KEY = os.environ.get("SECRET_KEY", "demo-secret-key-flash-neiga-sqlite")
 ALGORITHM = "HS256"
 
 security = HTTPBearer()
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+# Longueur minimale imposée partout (inscription, rattachement d'un paiement,
+# réinitialisation depuis le CRM) pour éviter les règles divergentes.
+MIN_PASSWORD_LENGTH = 6
+
+
+# ===== Identifiants =====
+def normalize_email(email: Optional[str]) -> str:
+    """Forme canonique d'un email : sans espaces et en minuscules.
+
+    Les élèves saisissent souvent leur email avec une majuscule initiale (ou un
+    espace ajouté par le clavier du téléphone). Sans normalisation, le compte
+    créé et le compte recherché à la connexion peuvent différer.
+    """
+    return (email or "").strip().lower()
+
+
+def hash_password(password: str) -> str:
+    return pwd_context.hash(password)
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    """Vérifie un mot de passe sans jamais lever d'exception.
+
+    Un hash absent ou illisible (compte importé, donnée corrompue) doit se
+    traduire par « identifiants invalides », pas par une erreur 500.
+    """
+    if not plain_password or not hashed_password:
+        return False
+    try:
+        return pwd_context.verify(plain_password, hashed_password)
+    except Exception:
+        return False
+
+
+def validate_password(password: Optional[str]) -> str:
+    """Contrôle la longueur du mot de passe et renvoie la valeur nettoyée."""
+    password = password or ""
+    if len(password) < MIN_PASSWORD_LENGTH:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Le mot de passe doit contenir au moins {MIN_PASSWORD_LENGTH} caractères.",
+        )
+    return password
+
+
+def find_user_by_email(db: Session, email: Optional[str]) -> Optional[UserDB]:
+    """Recherche un compte par email, sans tenir compte de la casse."""
+    normalized = normalize_email(email)
+    if not normalized:
+        return None
+    return db.query(UserDB).filter(func.lower(UserDB.email) == normalized).first()
+
+
+def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
+    to_encode = data.copy()
+    expire = datetime.now(timezone.utc) + (expires_delta or timedelta(hours=24))
+    to_encode.update({"exp": expire})
+    return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
 
 
 async def get_current_user(

--- a/backend/routes/admin_crm.py
+++ b/backend/routes/admin_crm.py
@@ -14,10 +14,12 @@ utilisateur authentifié dont l'email figure dans ADMIN_EMAILS).
   POST   /api/admin/crm/users/{user_id}/subscriptions  → accorder / prolonger un abonnement
   POST   /api/admin/crm/subscriptions/{sub_id}/cancel  → résilier un abonnement
   GET    /api/admin/crm/transactions                   → historique des paiements
+  POST   /api/admin/crm/transactions/{id}/attach       → rattacher un paiement à un compte
   GET    /api/admin/crm/plans                          → catalogue des formules
 """
 import json
 import logging
+import secrets
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -33,7 +35,8 @@ try:
         UserDB, SubscriptionDB, TransactionDB, PaymentDB,
         ExamSessionDB, UserMistakeDB, User, PromoCodeDB, PromoRedemptionDB,
     )
-    from auth import require_admin
+    from auth import require_admin, hash_password, normalize_email, find_user_by_email
+    from routes.hyp_payments import provision_subscription, transaction_email
     import promo as promo_lib
 except ImportError:  # pragma: no cover - import depuis la racine du repo
     from backend.database import get_db
@@ -41,7 +44,8 @@ except ImportError:  # pragma: no cover - import depuis la racine du repo
         UserDB, SubscriptionDB, TransactionDB, PaymentDB,
         ExamSessionDB, UserMistakeDB, User, PromoCodeDB, PromoRedemptionDB,
     )
-    from backend.auth import require_admin
+    from backend.auth import require_admin, hash_password, normalize_email, find_user_by_email
+    from backend.routes.hyp_payments import provision_subscription, transaction_email
     from backend import promo as promo_lib
 
 logger = logging.getLogger(__name__)
@@ -69,6 +73,14 @@ class UserUpdate(BaseModel):
 
 class PasswordReset(BaseModel):
     new_password: str
+
+
+class TransactionAttach(BaseModel):
+    """Rattachement manuel d'un paiement à un compte élève."""
+    email: EmailStr
+    first_name: Optional[str] = None
+    last_name: Optional[str] = None
+    password: Optional[str] = None   # None = mot de passe provisoire généré
 
 
 class SubscriptionGrant(BaseModel):
@@ -443,9 +455,7 @@ async def reset_user_password(user_id: str, payload: PasswordReset, db: Session 
     if not user:
         raise HTTPException(status_code=404, detail="Utilisateur introuvable")
 
-    from passlib.context import CryptContext
-    pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
-    user.hashed_password = pwd_context.hash(payload.new_password)
+    user.hashed_password = hash_password(payload.new_password)
     db.add(user)
     db.commit()
     logger.info("CRM : mot de passe réinitialisé pour %s", user.email)
@@ -559,12 +569,20 @@ async def cancel_subscription(sub_id: str, db: Session = Depends(get_db)):
 async def list_transactions(
     db: Session = Depends(get_db),
     status: Optional[str] = Query(None, description="pending / completed / failed …"),
+    needs_account: bool = Query(
+        False, description="Uniquement les paiements encaissés sans compte rattaché"
+    ),
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
 ):
     query = db.query(TransactionDB)
     if status:
         query = query.filter(TransactionDB.status == status)
+    if needs_account:
+        # Paiement encaissé dont personne ne profite : aucun compte ne le porte.
+        query = query.filter(
+            TransactionDB.status == "completed", TransactionDB.user_id.is_(None)
+        )
     total = query.count()
     rows = (
         query.order_by(TransactionDB.created_at.desc()).offset(offset).limit(limit).all()
@@ -581,7 +599,14 @@ async def list_transactions(
             {
                 "id": t.id,
                 "user_id": t.user_id,
-                "user_email": (users.get(t.user_id).email if users.get(t.user_id) else None),
+                # Sans compte rattaché, on affiche l'email saisi au paiement :
+                # c'est la seule piste pour retrouver l'élève.
+                "user_email": (
+                    users.get(t.user_id).email if users.get(t.user_id)
+                    else transaction_email(t)
+                ),
+                "has_account": bool(t.user_id),
+                "needs_account": t.status == "completed" and not t.user_id,
                 "plan_id": t.plan_id,
                 "plan_name": _plan_name(t.plan_id),
                 "amount": t.amount,
@@ -596,6 +621,71 @@ async def list_transactions(
         "limit": limit,
         "offset": offset,
         "has_more": offset + len(rows) < total,
+    }
+
+
+@router.post("/transactions/{transaction_id}/attach")
+async def attach_transaction(
+    transaction_id: str,
+    payload: TransactionAttach,
+    db: Session = Depends(get_db),
+    admin: User = Depends(require_admin),
+):
+    """Rattache un paiement encaissé à un compte élève et ouvre son abonnement.
+
+    Sert quand un élève a payé mais ne peut pas entrer : soit le compte n'existe
+    pas encore (il est créé ici, avec un mot de passe provisoire à lui
+    communiquer), soit il existe déjà et le paiement lui est simplement affecté.
+    """
+    transaction = db.query(TransactionDB).filter(TransactionDB.id == transaction_id).first()
+    if not transaction:
+        raise HTTPException(status_code=404, detail="Paiement introuvable")
+    if transaction.user_id:
+        raise HTTPException(status_code=409, detail="Ce paiement est déjà rattaché à un compte")
+    if transaction.status != "completed":
+        raise HTTPException(
+            status_code=409,
+            detail=f"Paiement non encaissé (statut : {transaction.status})",
+        )
+
+    email = normalize_email(payload.email)
+    user = find_user_by_email(db, email)
+    temporary_password = None
+    if not user:
+        temporary_password = payload.password or secrets.token_urlsafe(9)
+        user = UserDB(
+            email=email,
+            hashed_password=hash_password(temporary_password),
+            first_name=(payload.first_name or "").strip() or None,
+            last_name=(payload.last_name or "").strip() or None,
+        )
+        db.add(user)
+        db.flush()
+    elif payload.password:
+        user.hashed_password = hash_password(payload.password)
+        temporary_password = payload.password
+        db.add(user)
+
+    transaction.user_id = user.id
+    event_data = dict(transaction.event_data or {})
+    event_data.update({
+        "needs_account": False,
+        "attached_by": admin.email,
+        "attached_at": datetime.utcnow().isoformat(),
+    })
+    event_data.setdefault("user_email", email)
+    transaction.event_data = event_data
+
+    subscription = provision_subscription(db, transaction)
+    db.commit()
+
+    logger.info("CRM : paiement %s rattaché à %s par %s", transaction.id, email, admin.email)
+    return {
+        "status": "ok",
+        "user": {"id": user.id, "email": user.email},
+        # Renvoyé une seule fois, à transmettre à l'élève : il pourra le changer.
+        "temporary_password": temporary_password,
+        "subscription": _sub_payload(subscription),
     }
 
 

--- a/backend/routes/hyp_payments.py
+++ b/backend/routes/hyp_payments.py
@@ -25,10 +25,18 @@ except ImportError:
     from backend.database import get_db
 
 try:
-    from models import TransactionDB, SubscriptionDB, UserDB
+    from models import TransactionDB, SubscriptionDB, UserDB, User
+    from auth import (
+        get_current_user_optional, hash_password, create_access_token,
+        normalize_email, find_user_by_email, validate_password, verify_password,
+    )
     import promo as promo_lib
 except ImportError:
-    from backend.models import TransactionDB, SubscriptionDB, UserDB
+    from backend.models import TransactionDB, SubscriptionDB, UserDB, User
+    from backend.auth import (
+        get_current_user_optional, hash_password, create_access_token,
+        normalize_email, find_user_by_email, validate_password, verify_password,
+    )
     from backend import promo as promo_lib
 
 logger = logging.getLogger(__name__)
@@ -96,6 +104,20 @@ class ValidatePromoRequest(BaseModel):
     user_id: Optional[str] = None
 
 
+class ClaimAccessRequest(BaseModel):
+    """Rattachement d'un paiement encaissé à un compte élève.
+
+    Filet de sécurité pour les paiements qui, pour une raison ou une autre, sont
+    arrivés sans compte associé : l'élève choisit son mot de passe et récupère
+    immédiatement l'accès qu'il a payé.
+    """
+    transaction_id: str
+    email: EmailStr
+    password: str
+    first_name: Optional[str] = None
+    last_name: Optional[str] = None
+
+
 class CallbackData(BaseModel):
     """Model for HYP callback data"""
     Id: Optional[str] = None
@@ -126,6 +148,84 @@ def calculate_subscription_dates(plan_id: str, start_date: Optional[datetime] = 
     end_date = start_date + timedelta(days=duration_days)
     
     return start_date, end_date
+
+
+def transaction_email(transaction: TransactionDB) -> Optional[str]:
+    """Email connu pour ce paiement : celui saisi chez nous, sinon celui de HYP."""
+    for source in (transaction.event_data, transaction.callback_data):
+        if isinstance(source, dict):
+            for key in ("user_email", "email", "Email", "UserEmail", "client_email"):
+                value = source.get(key)
+                if value:
+                    return normalize_email(str(value))
+    return None
+
+
+def mask_email(email: Optional[str]) -> Optional[str]:
+    """`sarah.cohen@gmail.com` → `sa****n@gmail.com`.
+
+    Sert à confirmer à l'élève quel email a servi au paiement sans exposer
+    l'adresse complète à quiconque détiendrait l'identifiant de transaction.
+    """
+    if not email or "@" not in email:
+        return None
+    local, domain = email.rsplit("@", 1)
+    if len(local) <= 2:
+        return f"{local[0]}***@{domain}"
+    return f"{local[:2]}{'*' * max(3, len(local) - 3)}{local[-1]}@{domain}"
+
+
+def provision_subscription(db: Session, transaction: TransactionDB) -> Optional[SubscriptionDB]:
+    """Crée (ou prolonge) l'abonnement correspondant à un paiement encaissé.
+
+    Isolé du callback pour être rejouable : c'est la même fonction qui sert
+    lorsqu'un paiement est rattaché après coup à un compte (voir /claim et le
+    CRM). Ne committe pas : l'appelant maîtrise la transaction SQL.
+    """
+    if not (transaction.user_id and transaction.plan_id):
+        return None
+
+    plan = get_plan(transaction.plan_id) or {}
+    plan_type = plan.get("type")
+    is_extension = plan.get("is_extension", False)
+
+    # Filtrage en Python plutôt qu'un LIKE construit à partir du plan.
+    existing_subs = db.query(SubscriptionDB).filter(
+        SubscriptionDB.user_id == transaction.user_id,
+        SubscriptionDB.status == "active",
+    ).all()
+    existing_sub = next(
+        (s for s in existing_subs if s.plan_id and s.plan_id.startswith(f"{plan_type}_")),
+        None,
+    )
+
+    if existing_sub and is_extension:
+        # Prolongation : on repart de la date de fin en cours.
+        base_date = existing_sub.end_date or datetime.utcnow()
+        _, end_date = calculate_subscription_dates(transaction.plan_id, base_date)
+        existing_sub.end_date = end_date
+        existing_sub.updated_at = datetime.utcnow()
+        db.add(existing_sub)
+        logger.info(f"Extended subscription {existing_sub.id} to {end_date}")
+        return existing_sub
+
+    start_date, end_date = calculate_subscription_dates(transaction.plan_id)
+    if existing_sub:
+        existing_sub.status = "expired"
+        existing_sub.updated_at = datetime.utcnow()
+        db.add(existing_sub)
+
+    subscription = SubscriptionDB(
+        user_id=transaction.user_id,
+        plan_id=transaction.plan_id,
+        start_date=start_date,
+        end_date=end_date,
+        status="active",
+        transaction_id=transaction.id,
+    )
+    db.add(subscription)
+    logger.info(f"Created new subscription for user {transaction.user_id}")
+    return subscription
 
 
 def _hyp_coin(currency: str) -> int:
@@ -417,16 +517,22 @@ async def validate_promo(request: ValidatePromoRequest, db: Session = Depends(ge
 @router.post("/create-payment", response_model=CreatePaymentResponse)
 async def create_payment(
     request: CreatePaymentRequest,
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    current_user: Optional[User] = Depends(get_current_user_optional),
 ):
     """
     Create a HYP payment link
-    
+
     This endpoint:
     1. Validates the plan
-    2. Creates a transaction record
-    3. Generates a HYP payment URL
-    4. Returns the URL for user redirection
+    2. Identifies the buyer (an account is required)
+    3. Creates a transaction record
+    4. Generates a HYP payment URL
+    5. Returns the URL for user redirection
+
+    Le compte est exigé AVANT le paiement : un abonnement ne peut exister que
+    rattaché à un élève. Sans cette règle, un paiement anonyme est encaissé sans
+    qu'aucun accès ne puisse être ouvert.
     """
     # Validate plan
     plan = get_plan(request.plan_id)
@@ -435,18 +541,28 @@ async def create_payment(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Invalid plan_id: {request.plan_id}"
         )
-    
-    # Verify user exists if user_id provided
-    if request.user_id:
+
+    # L'élève connecté prime toujours sur ce que dit le client : c'est son compte
+    # qui sera crédité, quel que soit le user_id envoyé dans le corps.
+    if current_user:
+        request.user_id = current_user.id
+        user_email = normalize_email(current_user.email)
+    elif request.user_id:
         user = db.query(UserDB).filter(UserDB.id == request.user_id).first()
         if not user:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail="User not found"
             )
-        user_email = request.user_email or user.email
+        user_email = normalize_email(request.user_email or user.email)
     else:
-        user_email = request.user_email
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=(
+                "Crée ton compte (ou connecte-toi) avant de payer : "
+                "ton abonnement doit être rattaché à un compte pour être activé."
+            ),
+        )
 
     # Code promo : le montant est TOUJOURS recalculé côté serveur à partir du
     # catalogue ; le client n'envoie qu'un code, jamais un prix.
@@ -462,7 +578,16 @@ async def create_payment(
         except promo_lib.PromoError as exc:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
 
-    # Create transaction record
+    # Create transaction record. L'email est TOUJOURS conservé (et pas seulement
+    # avec un code promo) : c'est ce qui permet de retrouver l'élève si un
+    # paiement doit être rapproché manuellement d'un compte.
+    event_data: Dict[str, Any] = {"user_email": user_email}
+    if applied_promo:
+        event_data.update({
+            "promo_code": applied_promo.code,
+            "original_amount": original_amount,
+            "discount_amount": discount,
+        })
     transaction = TransactionDB(
         user_id=request.user_id,
         plan_id=request.plan_id,
@@ -470,11 +595,7 @@ async def create_payment(
         currency=plan["currency"],
         status="pending",
         event_type="payment.created",
-        event_data=(
-            {"promo_code": applied_promo.code, "original_amount": original_amount,
-             "discount_amount": discount, "user_email": user_email}
-            if applied_promo else None
-        ),
+        event_data=event_data,
     )
 
     db.add(transaction)
@@ -493,22 +614,7 @@ async def create_payment(
         transaction.status = "completed"
         transaction.completed_at = datetime.utcnow()
         transaction.event_type = "payment.free"
-        start_date, end_date = calculate_subscription_dates(request.plan_id)
-        for old in db.query(SubscriptionDB).filter(
-            SubscriptionDB.user_id == request.user_id,
-            SubscriptionDB.status == "active",
-        ).all():
-            old.status = "expired"
-            old.updated_at = datetime.utcnow()
-            db.add(old)
-        db.add(SubscriptionDB(
-            user_id=request.user_id,
-            plan_id=request.plan_id,
-            start_date=start_date,
-            end_date=end_date,
-            status="active",
-            transaction_id=transaction.id,
-        ))
+        provision_subscription(db, transaction)
         promo_lib.redeem(
             db, applied_promo, request.plan_id, original_amount, discount, amount,
             user_id=request.user_id, user_email=user_email, transaction_id=transaction.id,
@@ -695,66 +801,28 @@ async def process_hyp_callback(data: Dict[str, Any], db: Session):
                 )
 
         # Create or extend subscription
-        if transaction.user_id and transaction.plan_id:
-            # Check for existing active subscription of the same type
-            plan = get_plan(transaction.plan_id)
-            plan_type = plan.get("type")
-            is_extension = plan.get("is_extension", False)
-            
-            # Use startswith() to avoid SQL injection with LIKE
-            # Only match subscriptions where plan_id starts with plan_type
-            existing_sub = db.query(SubscriptionDB).filter(
-                SubscriptionDB.user_id == transaction.user_id,
-                SubscriptionDB.status == "active"
-            ).all()
-            
-            # Filter in Python to avoid SQL injection
-            existing_sub = [
-                sub for sub in existing_sub 
-                if sub.plan_id and sub.plan_id.startswith(f"{plan_type}_")
-            ]
-            existing_sub = existing_sub[0] if existing_sub else None
-            
-            if existing_sub and is_extension:
-                # Extend existing subscription
-                if existing_sub.end_date:
-                    start_date = existing_sub.end_date
-                else:
-                    start_date = datetime.utcnow()
-                
-                start_date, end_date = calculate_subscription_dates(
-                    transaction.plan_id,
-                    start_date
-                )
-                
-                existing_sub.end_date = end_date
-                existing_sub.updated_at = datetime.utcnow()
-                
-                logger.info(f"Extended subscription {existing_sub.id} to {end_date}")
-            else:
-                # Create new subscription
-                start_date, end_date = calculate_subscription_dates(transaction.plan_id)
-                
-                # Deactivate old subscriptions of the same type
-                if existing_sub:
-                    existing_sub.status = "expired"
-                    existing_sub.updated_at = datetime.utcnow()
-                
-                subscription = SubscriptionDB(
-                    user_id=transaction.user_id,
-                    plan_id=transaction.plan_id,
-                    start_date=start_date,
-                    end_date=end_date,
-                    status="active",
-                    transaction_id=transaction.id
-                )
-                
-                db.add(subscription)
-                logger.info(f"Created new subscription for user {transaction.user_id}")
-        
+        provision_subscription(db, transaction)
+
+        # Paiement encaissé sans compte rattaché : l'abonnement ne peut pas être
+        # créé. On le trace explicitement (alerte dans les logs + drapeau visible
+        # dans le CRM) et l'élève se voit proposer de finaliser son compte sur la
+        # page de confirmation, via /claim.
+        if not transaction.user_id:
+            logger.error(
+                "⚠️ Paiement %s encaissé SANS COMPTE (email connu : %s) — "
+                "abonnement en attente de rattachement",
+                transaction.id, transaction_email(transaction) or "inconnu",
+            )
+            event_data = dict(transaction.event_data or {})
+            event_data["needs_account"] = True
+            hyp_email = data.get("email") or data.get("Email")
+            if hyp_email and not event_data.get("user_email"):
+                event_data["user_email"] = normalize_email(str(hyp_email))
+            transaction.event_data = event_data
+
         db.commit()
         logger.info(f"Transaction {transaction_id} completed successfully")
-        
+
         return {"status": "success", "message": "Payment completed"}
     else:
         # Payment failed
@@ -809,11 +877,16 @@ async def get_transaction(
             detail="Transaction not found"
         )
     
-    # Build base response
+    # Build base response. `needs_account` dit à la page de confirmation qu'il
+    # reste une étape : le paiement est encaissé mais aucun compte ne le porte.
+    # L'email n'est renvoyé que masqué : l'identifiant de transaction ne doit pas
+    # suffire à lire l'adresse d'un élève.
+    needs_account = transaction.status == "completed" and not transaction.user_id
     response = {
         "id": transaction.id,
         "user_id": transaction.user_id,
         "plan_id": transaction.plan_id,
+        "plan_name": (get_plan(transaction.plan_id) or {}).get("name") or transaction.plan_id,
         "amount": transaction.amount,
         "currency": transaction.currency,
         "status": transaction.status,
@@ -821,9 +894,11 @@ async def get_transaction(
         "hyp_transaction_id": transaction.hyp_transaction_id,
         "created_at": transaction.created_at.isoformat() if transaction.created_at else None,
         "completed_at": transaction.completed_at.isoformat() if transaction.completed_at else None,
-        "callback_data": transaction.callback_data
+        "callback_data": transaction.callback_data,
+        "needs_account": needs_account,
+        "email_hint": mask_email(transaction_email(transaction)) if needs_account else None,
     }
-    
+
     # If transaction is completed, try to fetch associated subscription
     if transaction.status == "completed" and transaction.user_id:
         subscription = db.query(SubscriptionDB).filter(
@@ -847,6 +922,89 @@ async def get_transaction(
             logger.debug(f"Added subscription details to transaction {transaction_id}")
     
     return response
+
+
+@router.post("/claim")
+async def claim_payment(request: ClaimAccessRequest, db: Session = Depends(get_db)):
+    """Rattache un paiement encaissé à un compte élève et ouvre l'accès.
+
+    Utilisé sur la page de confirmation quand le paiement est arrivé sans compte
+    (ancien parcours anonyme, session perdue en cours de route…). L'élève choisit
+    son mot de passe et est connecté immédiatement : il n'a plus à deviner des
+    identifiants qu'il n'a jamais créés.
+
+    Garde-fous :
+      - le paiement doit être confirmé (statut `completed`) ;
+      - un paiement déjà rattaché ne peut pas être repris ;
+      - si l'email correspond à un compte existant, le mot de passe de ce compte
+        est exigé — on ne prend jamais la main sur le compte d'un tiers.
+    """
+    transaction = db.query(TransactionDB).filter(
+        TransactionDB.id == request.transaction_id
+    ).first()
+    if not transaction:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Paiement introuvable")
+
+    if transaction.status != "completed":
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Ce paiement n'est pas encore confirmé. Réessaie dans quelques instants.",
+        )
+
+    if transaction.user_id:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Ce paiement est déjà rattaché à un compte. Connecte-toi pour accéder à ton abonnement.",
+        )
+
+    email = normalize_email(request.email)
+    password = validate_password(request.password)
+
+    user = find_user_by_email(db, email)
+    if user:
+        # Compte existant : seul son propriétaire (celui qui connaît le mot de
+        # passe) peut y rattacher le paiement.
+        if not verify_password(password, user.hashed_password):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=(
+                    "Un compte existe déjà avec cet email. Saisis son mot de passe "
+                    "pour y rattacher ton abonnement."
+                ),
+            )
+    else:
+        user = UserDB(
+            email=email,
+            hashed_password=hash_password(password),
+            first_name=(request.first_name or "").strip() or None,
+            last_name=(request.last_name or "").strip() or None,
+        )
+        db.add(user)
+        db.flush()  # attribue l'id avant de rattacher le paiement
+
+    transaction.user_id = user.id
+    event_data = dict(transaction.event_data or {})
+    event_data["needs_account"] = False
+    event_data["claimed_at"] = datetime.utcnow().isoformat()
+    event_data.setdefault("user_email", email)
+    transaction.event_data = event_data
+
+    subscription = provision_subscription(db, transaction)
+    db.commit()
+
+    logger.info("Paiement %s rattaché au compte %s", transaction.id, email)
+
+    return {
+        "status": "ok",
+        "access_token": create_access_token(data={"sub": user.id}),
+        "token_type": "bearer",
+        "user": {"id": user.id, "email": user.email},
+        "subscription": {
+            "plan_id": subscription.plan_id,
+            "end_date": subscription.end_date.isoformat() if subscription and subscription.end_date else None,
+            "status": subscription.status,
+        } if subscription else None,
+    }
 
 
 @router.get("/subscriptions/{user_id}")

--- a/backend/server.py
+++ b/backend/server.py
@@ -80,9 +80,17 @@ try:
 except ImportError:
     from backend.routes.admin_crm import router as admin_crm_router
 try:
-    from auth import get_current_user, get_current_user_optional, require_admin, require_subscription
+    from auth import (
+        get_current_user, get_current_user_optional, require_admin, require_subscription,
+        hash_password, verify_password, create_access_token, normalize_email,
+        find_user_by_email, validate_password,
+    )
 except ImportError:
-    from backend.auth import get_current_user, get_current_user_optional, require_admin, require_subscription
+    from backend.auth import (
+        get_current_user, get_current_user_optional, require_admin, require_subscription,
+        hash_password, verify_password, create_access_token, normalize_email,
+        find_user_by_email, validate_password,
+    )
 try:
     from migrations.auto_migrate import run_hyp_migration
 except ImportError:
@@ -167,23 +175,9 @@ def init_db():
 
 
 # ===== Auth Helpers =====
-def hash_password(password: str) -> str:
-    return pwd_context.hash(password)
-
-
-def verify_password(plain_password: str, hashed_password: str) -> bool:
-    return pwd_context.verify(plain_password, hashed_password)
-
-
-def create_access_token(data: dict, expires_delta: Optional[timedelta] = None):
-    to_encode = data.copy()
-    if expires_delta:
-        expire = datetime.now(timezone.utc) + expires_delta
-    else:
-        expire = datetime.now(timezone.utc) + timedelta(hours=24)
-    to_encode.update({"exp": expire})
-    encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
-    return encoded_jwt
+# hash_password / verify_password / create_access_token vivent dans auth.py :
+# le module des paiements en a besoin lui aussi (rattachement d'un paiement à
+# un compte) et ne peut pas importer server.py sans créer un import circulaire.
 
 
 # ===== Init Data =====
@@ -644,14 +638,20 @@ async def dev_seed(
 # ===== Auth Endpoints =====
 @app.post("/api/auth/register", response_model=TokenResponse)
 async def register(user_in: UserCreate, db: Session = Depends(get_db)):
+    # L'email est normalisé (minuscules, sans espaces) : c'est la clé du compte,
+    # et une majuscule involontaire ne doit pas créer un second compte ni
+    # empêcher la connexion.
+    email = normalize_email(user_in.email)
+    password = validate_password(user_in.password)
+
     # Check if user exists
-    existing_user = db.query(UserDB).filter(UserDB.email == user_in.email).first()
+    existing_user = find_user_by_email(db, email)
     if existing_user:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Email already registered"
+            detail="Un compte existe déjà avec cet email. Connecte-toi.",
         )
-    
+
     # Prénom / nom : champs dédiés, avec repli sur l'ancien "full_name"
     first_name = (user_in.first_name or "").strip() or None
     last_name = (user_in.last_name or "").strip() or None
@@ -664,8 +664,8 @@ async def register(user_in: UserCreate, db: Session = Depends(get_db)):
     user_id = str(uuid.uuid4())
     user = UserDB(
         id=user_id,
-        email=user_in.email,
-        hashed_password=hash_password(user_in.password),
+        email=email,
+        hashed_password=hash_password(password),
         first_name=first_name,
         last_name=last_name,
     )
@@ -680,13 +680,15 @@ async def register(user_in: UserCreate, db: Session = Depends(get_db)):
 
 @app.post("/api/auth/login", response_model=TokenResponse)
 async def login(form_data: OAuth2PasswordRequestForm = Depends(), db: Session = Depends(get_db)):
-    user = db.query(UserDB).filter(UserDB.email == form_data.username).first()
+    # Recherche insensible à la casse : les comptes créés avant la normalisation
+    # peuvent contenir des majuscules, l'élève ne doit pas avoir à les deviner.
+    user = find_user_by_email(db, form_data.username)
     if not user or not verify_password(form_data.password, user.hashed_password):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid credentials"
+            detail="Email ou mot de passe incorrect."
         )
-    
+
     access_token = create_access_token(data={"sub": user.id})
     return TokenResponse(access_token=access_token)
 

--- a/backend/tests/test_admin_crm_attach.py
+++ b/backend/tests/test_admin_crm_attach.py
@@ -1,0 +1,169 @@
+"""
+CRM : rattrapage d'un paiement encaissé sans compte.
+
+C'est l'outil de dépannage de l'équipe quand un élève a payé mais ne peut pas
+entrer : le paiement est rattaché à un compte (créé au besoin) et l'abonnement
+s'ouvre immédiatement.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+backend_path = Path(__file__).parent.parent
+sys.path.insert(0, str(backend_path))
+
+from server import app
+from database import Base, get_db
+from models import TransactionDB, SubscriptionDB, UserDB
+
+SQLALCHEMY_TEST_DATABASE_URL = "sqlite:///./test_admin_crm_attach.db"
+engine = create_engine(SQLALCHEMY_TEST_DATABASE_URL, connect_args={"check_same_thread": False})
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+ADMIN_EMAIL = "admin@gmail.com"   # valeur par défaut de ADMIN_EMAILS
+
+
+def override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@pytest.fixture(scope="function")
+def test_db():
+    previous = app.dependency_overrides.get(get_db)
+    app.dependency_overrides[get_db] = override_get_db
+    Base.metadata.create_all(bind=engine)
+    try:
+        yield TestingSessionLocal()
+    finally:
+        Base.metadata.drop_all(bind=engine)
+        if previous is None:
+            app.dependency_overrides.pop(get_db, None)
+        else:
+            app.dependency_overrides[get_db] = previous
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def admin_headers(client, test_db):
+    response = client.post(
+        "/api/auth/register",
+        json={"email": ADMIN_EMAIL, "password": "motdepasse-admin"},
+    )
+    assert response.status_code == 200
+    return {"Authorization": f"Bearer {response.json()['access_token']}"}
+
+
+@pytest.fixture
+def orphan_transaction(test_db):
+    """Paiement encaissé auquel aucun compte n'est rattaché."""
+    transaction = TransactionDB(
+        plan_id="code_14d",
+        amount=99,
+        currency="ILS",
+        status="completed",
+        event_data={"user_email": "sarah@example.com", "needs_account": True},
+    )
+    test_db.add(transaction)
+    test_db.commit()
+    test_db.refresh(transaction)
+    return transaction
+
+
+def test_orphan_payments_are_listed(client, test_db, admin_headers, orphan_transaction):
+    response = client.get(
+        "/api/admin/crm/transactions", params={"needs_account": True}, headers=admin_headers
+    )
+    assert response.status_code == 200
+
+    items = response.json()["items"]
+    assert len(items) == 1
+    assert items[0]["needs_account"] is True
+    assert items[0]["has_account"] is False
+    # L'email saisi au paiement reste la piste pour retrouver l'élève.
+    assert items[0]["user_email"] == "sarah@example.com"
+
+
+def test_attach_creates_account_and_opens_subscription(client, test_db, admin_headers, orphan_transaction):
+    response = client.post(
+        f"/api/admin/crm/transactions/{orphan_transaction.id}/attach",
+        json={"email": "Sarah@Example.com", "first_name": "Sarah", "last_name": "Cohen"},
+        headers=admin_headers,
+    )
+    assert response.status_code == 200
+    data = response.json()
+
+    assert data["user"]["email"] == "sarah@example.com"
+    assert data["subscription"]["status"] == "active"
+    # Mot de passe provisoire à transmettre à l'élève.
+    assert data["temporary_password"]
+
+    login = client.post(
+        "/api/auth/login",
+        data={"username": "sarah@example.com", "password": data["temporary_password"]},
+    )
+    assert login.status_code == 200
+
+    test_db.refresh(orphan_transaction)
+    assert orphan_transaction.user_id == data["user"]["id"]
+    assert orphan_transaction.event_data["attached_by"] == ADMIN_EMAIL
+
+
+def test_attach_to_existing_account_keeps_its_password(client, test_db, admin_headers, orphan_transaction):
+    client.post("/api/auth/register", json={"email": "sarah@example.com", "password": "motdepasse"})
+
+    response = client.post(
+        f"/api/admin/crm/transactions/{orphan_transaction.id}/attach",
+        json={"email": "sarah@example.com"},
+        headers=admin_headers,
+    )
+    assert response.status_code == 200
+    assert response.json()["temporary_password"] is None
+
+    assert test_db.query(UserDB).filter(UserDB.email == "sarah@example.com").count() == 1
+    login = client.post(
+        "/api/auth/login", data={"username": "sarah@example.com", "password": "motdepasse"}
+    )
+    assert login.status_code == 200
+
+
+def test_attach_is_refused_twice(client, test_db, admin_headers, orphan_transaction):
+    first = client.post(
+        f"/api/admin/crm/transactions/{orphan_transaction.id}/attach",
+        json={"email": "sarah@example.com"},
+        headers=admin_headers,
+    )
+    assert first.status_code == 200
+
+    second = client.post(
+        f"/api/admin/crm/transactions/{orphan_transaction.id}/attach",
+        json={"email": "autre@example.com"},
+        headers=admin_headers,
+    )
+    assert second.status_code == 409
+    assert test_db.query(SubscriptionDB).count() == 1
+
+
+def test_attach_requires_admin(client, test_db, orphan_transaction):
+    eleve = client.post(
+        "/api/auth/register", json={"email": "eleve@example.com", "password": "motdepasse"}
+    )
+    response = client.post(
+        f"/api/admin/crm/transactions/{orphan_transaction.id}/attach",
+        json={"email": "eleve@example.com"},
+        headers={"Authorization": f"Bearer {eleve.json()['access_token']}"},
+    )
+    assert response.status_code == 403
+    assert test_db.query(SubscriptionDB).count() == 0

--- a/backend/tests/test_auth_accounts.py
+++ b/backend/tests/test_auth_accounts.py
@@ -1,0 +1,115 @@
+"""
+Création de compte et connexion.
+
+Couvre les pièges qui empêchent un élève d'entrer sur la plateforme alors qu'il
+a bien un compte : casse de l'email, espaces parasites, mot de passe trop court.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+backend_path = Path(__file__).parent.parent
+sys.path.insert(0, str(backend_path))
+
+from server import app
+from database import Base, get_db
+from models import UserDB
+
+SQLALCHEMY_TEST_DATABASE_URL = "sqlite:///./test_auth_accounts.db"
+engine = create_engine(SQLALCHEMY_TEST_DATABASE_URL, connect_args={"check_same_thread": False})
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@pytest.fixture(scope="function")
+def test_db():
+    # L'override est posé par test (et retiré ensuite) : d'autres modules de
+    # tests branchent leur propre base sur la même application.
+    previous = app.dependency_overrides.get(get_db)
+    app.dependency_overrides[get_db] = override_get_db
+    Base.metadata.create_all(bind=engine)
+    try:
+        yield TestingSessionLocal()
+    finally:
+        Base.metadata.drop_all(bind=engine)
+        if previous is None:
+            app.dependency_overrides.pop(get_db, None)
+        else:
+            app.dependency_overrides[get_db] = previous
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def register(client, email, password="motdepasse", **extra):
+    return client.post("/api/auth/register", json={"email": email, "password": password, **extra})
+
+
+def login(client, email, password="motdepasse"):
+    return client.post("/api/auth/login", data={"username": email, "password": password})
+
+
+def test_email_is_stored_normalized(client, test_db):
+    assert register(client, "  Sarah.Cohen@Gmail.COM  ").status_code == 200
+    user = test_db.query(UserDB).first()
+    assert user.email == "sarah.cohen@gmail.com"
+
+
+def test_login_ignores_case_and_spaces(client, test_db):
+    register(client, "Sarah@Gmail.com")
+
+    for typed in ("Sarah@Gmail.com", "sarah@gmail.com", " SARAH@GMAIL.COM "):
+        assert login(client, typed).status_code == 200, typed
+
+
+def test_login_works_on_legacy_account_stored_with_capitals(client, test_db):
+    """Comptes créés avant la normalisation : la connexion doit rester possible."""
+    from auth import hash_password
+
+    test_db.add(UserDB(
+        id="legacy-1",
+        email="Ancienne.Eleve@Gmail.com",
+        hashed_password=hash_password("motdepasse"),
+    ))
+    test_db.commit()
+
+    assert login(client, "ancienne.eleve@gmail.com").status_code == 200
+
+
+def test_same_email_in_another_case_is_not_a_second_account(client, test_db):
+    assert register(client, "sarah@gmail.com").status_code == 200
+    duplicate = register(client, "SARAH@gmail.com")
+
+    assert duplicate.status_code == 400
+    assert test_db.query(UserDB).count() == 1
+
+
+def test_short_password_is_refused(client, test_db):
+    response = register(client, "sarah@gmail.com", password="123")
+
+    assert response.status_code == 400
+    assert test_db.query(UserDB).count() == 0
+
+
+def test_wrong_password_is_refused(client, test_db):
+    register(client, "sarah@gmail.com")
+
+    assert login(client, "sarah@gmail.com", password="autre-mot-de-passe").status_code == 401
+
+
+def test_unknown_account_is_refused(client, test_db):
+    assert login(client, "inconnue@gmail.com").status_code == 401

--- a/backend/tests/test_hyp_integration.py
+++ b/backend/tests/test_hyp_integration.py
@@ -46,6 +46,18 @@ def test_db():
 def client():
     return TestClient(app)
 
+
+@pytest.fixture(autouse=True)
+def no_signature_check(monkeypatch):
+    """Les notifications HYP sont signées en production (HYP_REQUIRE_SIGNATURE).
+
+    Les tests ne disposent d'aucun terminal HYP pour produire une signature :
+    on désactive la vérification côté module, sans toucher au comportement par
+    défaut de l'application.
+    """
+    import routes.hyp_payments as hyp
+    monkeypatch.setattr(hyp, "HYP_REQUIRE_SIGNATURE", False)
+
 # Test data
 SAMPLE_USER = {
     "id": "test-user-123",
@@ -497,6 +509,196 @@ class TestGetUserSubscriptions:
         assert "subscriptions" in data
         assert data["count"] == 2
         assert len(data["subscriptions"]) == 2
+
+
+class TestAccountRequiredBeforePayment:
+    """Un paiement ne peut pas partir sans compte : c'est ce qui garantit que
+    l'abonnement encaissé pourra effectivement être ouvert."""
+
+    def test_create_payment_without_account_is_refused(self, client, test_db):
+        response = client.post(
+            "/api/payments/hyp/create-payment",
+            json={"plan_id": "code_14d", "user_email": "sarah@example.com"},
+        )
+        assert response.status_code == 401
+        assert "compte" in response.json()["detail"].lower()
+
+        # Aucun paiement ne doit avoir été amorcé.
+        assert test_db.query(TransactionDB).count() == 0
+
+    @patch('routes.hyp_payments.create_hyp_payment_url')
+    def test_authenticated_user_wins_over_client_payload(self, mock_create_url, client, test_db):
+        """Le compte crédité est celui du token, jamais le user_id envoyé par le client."""
+        mock_create_url.return_value = "https://icom.yaad.net/p/?test=true"
+
+        register = client.post(
+            "/api/auth/register",
+            json={"email": "sarah@example.com", "password": "motdepasse", "first_name": "Sarah"},
+        )
+        assert register.status_code == 200
+        token = register.json()["access_token"]
+
+        other = UserDB(id="autre-eleve", email="autre@example.com", hashed_password="x")
+        test_db.add(other)
+        test_db.commit()
+
+        response = client.post(
+            "/api/payments/hyp/create-payment",
+            json={"plan_id": "code_14d", "user_id": other.id},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 200
+
+        transaction = test_db.query(TransactionDB).filter(
+            TransactionDB.id == response.json()["transaction_id"]
+        ).first()
+        assert transaction.user_id != other.id
+        assert transaction.event_data["user_email"] == "sarah@example.com"
+
+
+class TestClaimPayment:
+    """Rattachement d'un paiement encaissé sans compte (parcours de rattrapage)."""
+
+    def _orphan_transaction(self, client, test_db, email="sarah@example.com"):
+        transaction = TransactionDB(
+            plan_id="code_14d",
+            amount=99,
+            currency="ILS",
+            status="pending",
+            event_data={"user_email": email},
+        )
+        test_db.add(transaction)
+        test_db.commit()
+
+        response = client.post(
+            "/api/payments/hyp/callback",
+            json={"Order": transaction.id, "CCode": "0", "Id": "hyp-orphan-1"},
+        )
+        assert response.status_code == 200
+        test_db.refresh(transaction)
+        return transaction
+
+    def test_payment_without_account_is_flagged(self, client, test_db):
+        transaction = self._orphan_transaction(client, test_db)
+
+        assert transaction.status == "completed"
+        assert transaction.event_data["needs_account"] is True
+        assert test_db.query(SubscriptionDB).count() == 0
+
+        details = client.get(f"/api/payments/hyp/transaction/{transaction.id}").json()
+        assert details["needs_account"] is True
+        # L'email n'est renvoyé que masqué.
+        assert details["email_hint"].endswith("@example.com")
+        assert "sarah@example.com" not in details["email_hint"]
+
+    def test_claim_creates_account_and_opens_subscription(self, client, test_db):
+        transaction = self._orphan_transaction(client, test_db)
+
+        response = client.post(
+            "/api/payments/hyp/claim",
+            json={
+                "transaction_id": transaction.id,
+                "email": "Sarah@Example.com ",
+                "password": "motdepasse",
+                "first_name": "Sarah",
+            },
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["subscription"]["status"] == "active"
+
+        # L'élève est connecté immédiatement, sans avoir à deviner d'identifiants.
+        me = client.get("/api/auth/me", headers={"Authorization": f"Bearer {data['access_token']}"})
+        assert me.status_code == 200
+        assert me.json()["email"] == "sarah@example.com"
+
+        test_db.refresh(transaction)
+        assert transaction.user_id == data["user"]["id"]
+        subscription = test_db.query(SubscriptionDB).filter(
+            SubscriptionDB.user_id == data["user"]["id"]
+        ).first()
+        assert subscription.status == "active"
+        assert subscription.transaction_id == transaction.id
+
+        # Le mot de passe choisi permet bien de se reconnecter ensuite.
+        login = client.post(
+            "/api/auth/login",
+            data={"username": "sarah@example.com", "password": "motdepasse"},
+        )
+        assert login.status_code == 200
+
+    def test_claim_is_single_use(self, client, test_db):
+        transaction = self._orphan_transaction(client, test_db)
+        payload = {
+            "transaction_id": transaction.id,
+            "email": "sarah@example.com",
+            "password": "motdepasse",
+        }
+        assert client.post("/api/payments/hyp/claim", json=payload).status_code == 200
+
+        second = client.post(
+            "/api/payments/hyp/claim",
+            json={**payload, "email": "voleur@example.com", "password": "autremotdepasse"},
+        )
+        assert second.status_code == 409
+
+    def test_claim_on_existing_account_requires_its_password(self, client, test_db):
+        client.post(
+            "/api/auth/register",
+            json={"email": "sarah@example.com", "password": "motdepasse"},
+        )
+        transaction = self._orphan_transaction(client, test_db)
+
+        refused = client.post(
+            "/api/payments/hyp/claim",
+            json={
+                "transaction_id": transaction.id,
+                "email": "sarah@example.com",
+                "password": "mauvais-mot-de-passe",
+            },
+        )
+        assert refused.status_code == 403
+        assert test_db.query(SubscriptionDB).count() == 0
+
+        accepted = client.post(
+            "/api/payments/hyp/claim",
+            json={
+                "transaction_id": transaction.id,
+                "email": "sarah@example.com",
+                "password": "motdepasse",
+            },
+        )
+        assert accepted.status_code == 200
+        assert accepted.json()["subscription"]["status"] == "active"
+
+    def test_claim_refuses_unconfirmed_payment(self, client, test_db):
+        transaction = TransactionDB(plan_id="code_14d", amount=99, currency="ILS", status="pending")
+        test_db.add(transaction)
+        test_db.commit()
+
+        response = client.post(
+            "/api/payments/hyp/claim",
+            json={
+                "transaction_id": transaction.id,
+                "email": "sarah@example.com",
+                "password": "motdepasse",
+            },
+        )
+        assert response.status_code == 409
+        assert test_db.query(SubscriptionDB).count() == 0
+
+    def test_claim_refuses_short_password(self, client, test_db):
+        transaction = self._orphan_transaction(client, test_db)
+
+        response = client.post(
+            "/api/payments/hyp/claim",
+            json={
+                "transaction_id": transaction.id,
+                "email": "sarah@example.com",
+                "password": "123",
+            },
+        )
+        assert response.status_code == 400
 
 
 if __name__ == "__main__":

--- a/docs/PARCOURS_ABONNEMENT.md
+++ b/docs/PARCOURS_ABONNEMENT.md
@@ -1,0 +1,73 @@
+# Parcours d'abonnement : du paiement à l'accès
+
+Ce document décrit comment un élève passe de la page Formules à son entraînement,
+et ce qu'il faut faire quand un paiement n'ouvre pas d'accès.
+
+## Règle de base
+
+**Un abonnement n'existe que rattaché à un compte.** Sans compte, un paiement est
+encaissé mais aucun accès ne peut être ouvert : l'élève se retrouve devant une
+page de connexion pour un compte qu'il n'a jamais créé.
+
+Le compte (donc le mot de passe) est donc demandé **avant** la redirection vers
+la banque.
+
+## Le parcours nominal
+
+1. `/pricing` — l'élève choisit sa formule.
+2. S'il n'est pas connecté, une fenêtre lui fait créer son compte (prénom, nom,
+   email, mot de passe) ou se connecter. Le paiement repart tout seul ensuite.
+3. `POST /api/payments/hyp/create-payment` — le compte est obligatoire :
+   l'identité vient du token, jamais du corps de la requête. Sans compte, la
+   route répond `401` et aucun paiement n'est amorcé.
+4. Redirection vers HYP, paiement.
+5. Retour sur `/payment/success` : la notification est transmise au backend, qui
+   vérifie la signature (APISign VERIFY) et ouvre l'abonnement.
+6. L'élève est connecté : il entre directement dans son entraînement.
+
+L'email est enregistré sur chaque transaction (`event_data.user_email`), y
+compris sans code promo : c'est la piste qui permet de retrouver un élève.
+
+## Rattrapage 1 — l'élève, depuis la page de confirmation
+
+Si un paiement arrive sans compte rattaché (ancien parcours anonyme, session
+perdue en route), `GET /api/payments/hyp/transaction/{id}` renvoie
+`needs_account: true` et la page de confirmation affiche un formulaire
+« Choisis ton mot de passe » au lieu du bouton d'accès.
+
+`POST /api/payments/hyp/claim` crée le compte, ouvre l'abonnement payé et
+connecte l'élève immédiatement. Garde-fous :
+
+- le paiement doit être confirmé (`completed`) ;
+- un paiement déjà rattaché ne peut pas être repris (`409`) ;
+- si l'email correspond à un compte existant, son mot de passe est exigé
+  (`403`) — on ne prend jamais la main sur le compte d'un tiers.
+
+## Rattrapage 2 — l'équipe, depuis le CRM
+
+Onglet **Paiements** du CRM :
+
+- un bandeau signale les paiements encaissés sans compte ;
+- le bouton **Rattacher** crée le compte s'il n'existe pas et ouvre l'abonnement
+  payé (`POST /api/admin/crm/transactions/{id}/attach`) ;
+- si le compte est créé, un **mot de passe provisoire** est affiché une seule
+  fois : à communiquer à l'élève, qui pourra le changer ;
+- si le compte existe déjà, son mot de passe n'est pas touché.
+
+Pour lister uniquement ces paiements :
+`GET /api/admin/crm/transactions?needs_account=true`.
+
+## Connexion : pièges déjà traités
+
+- Les emails sont normalisés (minuscules, sans espaces) à l'inscription et la
+  recherche est insensible à la casse : `Sarah@Gmail.com` et `sarah@gmail.com`
+  ouvrent le même compte, y compris pour les comptes créés avant cette règle.
+- Le mot de passe fait au minimum 6 caractères, contrôlé côté serveur.
+
+## Limite connue
+
+Il n'existe pas d'envoi d'email transactionnel dans le projet : il n'y a donc
+pas de « mot de passe oublié » en libre-service. Un élève qui a perdu son mot de
+passe doit passer par l'équipe (CRM → fiche élève → *Réinitialiser le mot de
+passe*). Brancher un service d'envoi (SMTP ou API) est le prérequis pour
+automatiser cette étape.

--- a/frontend/src/api/axiosConfig.js
+++ b/frontend/src/api/axiosConfig.js
@@ -61,7 +61,13 @@ axios.interceptors.response.use(
       return Promise.reject(error);
     }
 
-    if (error.response?.status === 401) {
+    // Ces appels traitent eux-mêmes leur 401 (échec de connexion, paiement
+    // lancé sans compte) : les rediriger vers /login ferait perdre à l'élève sa
+    // saisie ou la formule qu'il venait de choisir.
+    const url = error.config?.url || '';
+    const handledLocally = /\/api\/auth\/(login|register)|\/api\/payments\//.test(url);
+
+    if (error.response?.status === 401 && !handledLocally) {
       console.warn('🚫 Unauthorized (401) - Clearing token');
       localStorage.removeItem('token');
       delete axios.defaults.headers.common['Authorization'];

--- a/frontend/src/context/AuthContext.js
+++ b/frontend/src/context/AuthContext.js
@@ -37,19 +37,13 @@ export const AuthProvider = ({ children }) => {
         initAuth();
     }, []); // 🔒 Dependency array vide = exécution unique !
 
-    const login = async (email, password) => {
-        const formData = new FormData();
-        formData.append('username', email);
-        formData.append('password', password);
-
-        const res = await axios.post('/api/auth/login', formData);
-        const newToken = res.data.access_token;
-        
-        // Sauvegarder et configurer le token
+    // Ouvre la session à partir d'un token déjà obtenu (connexion classique,
+    // inscription, ou rattachement d'un paiement à un compte).
+    const loginWithToken = async (newToken) => {
         localStorage.setItem('token', newToken);
         axios.defaults.headers.common['Authorization'] = `Bearer ${newToken}`;
         setToken(newToken);
-        
+
         // Charger l'utilisateur immédiatement
         try {
             const userRes = await axios.get('/api/auth/me');
@@ -58,18 +52,28 @@ export const AuthProvider = ({ children }) => {
             console.error("Failed to load user after login:", error);
             throw error;
         }
-        
+
         return true;
     };
 
+    const login = async (email, password) => {
+        const formData = new FormData();
+        formData.append('username', email);
+        formData.append('password', password);
+
+        const res = await axios.post('/api/auth/login', formData);
+        return await loginWithToken(res.data.access_token);
+    };
+
     const register = async (email, password, firstName, lastName) => {
-        await axios.post('/api/auth/register', {
+        // L'inscription renvoie déjà un token : inutile de rejouer une connexion.
+        const res = await axios.post('/api/auth/register', {
             email,
             password,
             first_name: firstName,
             last_name: lastName,
         });
-        return await login(email, password);
+        return await loginWithToken(res.data.access_token);
     };
 
     const logout = () => {
@@ -80,11 +84,12 @@ export const AuthProvider = ({ children }) => {
     };
 
     return (
-        <AuthContext.Provider value={{ 
-            user, 
-            login, 
-            register, 
-            logout, 
+        <AuthContext.Provider value={{
+            user,
+            login,
+            loginWithToken,
+            register,
+            logout,
             loading, 
             isAuthenticated: !!user,
             token

--- a/frontend/src/pages/AdminCRM.js
+++ b/frontend/src/pages/AdminCRM.js
@@ -14,7 +14,8 @@ import {
 } from '../components/ui/dialog';
 import {
     Search, RefreshCw, Users, CreditCard, TrendingUp, Clock, ArrowLeft,
-    Trash2, Save, KeyRound, Gift, ShieldAlert, Ticket, Plus, Power,
+    Trash2, Save, KeyRound, Gift, ShieldAlert, Ticket, Plus, Power, UserPlus,
+    AlertTriangle,
 } from 'lucide-react';
 
 const money = (v, currency = 'ILS') =>
@@ -70,6 +71,11 @@ export default function AdminCRM() {
     const [plans, setPlans] = useState([]);
     const [transactions, setTransactions] = useState([]);
     const [txLoading, setTxLoading] = useState(false);
+    // Rattachement d'un paiement encaissé sans compte
+    const [attachTx, setAttachTx] = useState(null);
+    const [attachForm, setAttachForm] = useState({ email: '', first_name: '', last_name: '' });
+    const [attachSaving, setAttachSaving] = useState(false);
+    const [attachResult, setAttachResult] = useState(null);
 
     // Codes promo
     const [promos, setPromos] = useState([]);
@@ -166,6 +172,31 @@ export default function AdminCRM() {
             setTxLoading(false);
         }
     }, [handleError]);
+
+    // Rattache un paiement encaissé à un compte élève : le compte est créé s'il
+    // n'existe pas, et l'abonnement payé est ouvert dans la foulée.
+    const attachTransaction = useCallback(async () => {
+        if (!attachTx) return;
+        setAttachSaving(true);
+        try {
+            const { data } = await axios.post(
+                `/api/admin/crm/transactions/${attachTx.id}/attach`,
+                {
+                    email: attachForm.email.trim(),
+                    first_name: attachForm.first_name.trim() || null,
+                    last_name: attachForm.last_name.trim() || null,
+                },
+            );
+            setAttachResult(data);
+            toast.success('Paiement rattaché et abonnement ouvert');
+            fetchTransactions();
+            fetchStats();
+        } catch (error) {
+            handleError(error, 'Impossible de rattacher ce paiement');
+        } finally {
+            setAttachSaving(false);
+        }
+    }, [attachTx, attachForm, fetchTransactions, fetchStats, handleError]);
 
     useEffect(() => {
         fetchStats();
@@ -633,6 +664,16 @@ export default function AdminCRM() {
                             </Button>
                         </CardHeader>
                         <CardContent>
+                            {transactions.some((t) => t.needs_account) && (
+                                <div className="mb-4 flex items-start gap-3 rounded-xl border border-amber-300 bg-amber-50 dark:bg-amber-500/10 dark:border-amber-500/30 p-3">
+                                    <AlertTriangle className="h-5 w-5 text-amber-600 dark:text-amber-400 shrink-0 mt-0.5" />
+                                    <div className="text-sm text-amber-800 dark:text-amber-200">
+                                        <strong>{transactions.filter((t) => t.needs_account).length} paiement(s) encaissé(s) sans compte.</strong>{' '}
+                                        L'élève a payé mais aucun abonnement n'a pu être ouvert : rattache-le à un compte
+                                        pour lui donner l'accès.
+                                    </div>
+                                </div>
+                            )}
                             {txLoading ? (
                                 <div className="space-y-2">
                                     {Array.from({ length: 6 }).map((_, i) => <Skeleton key={i} className="h-12 w-full rounded-lg" />)}
@@ -649,17 +690,40 @@ export default function AdminCRM() {
                                                 <th className="py-2 pr-3">Formule</th>
                                                 <th className="py-2 pr-3">Montant</th>
                                                 <th className="py-2 pr-3">Statut</th>
+                                                <th className="py-2 pr-3"></th>
                                             </tr>
                                         </thead>
                                         <tbody>
                                             {transactions.map((t) => (
                                                 <tr key={t.id} className="border-b border-slate-100 dark:border-slate-700/50">
                                                     <td className="py-2 pr-3 text-slate-500 dark:text-slate-400">{date(t.created_at)}</td>
-                                                    <td className="py-2 pr-3 text-slate-700 dark:text-slate-200">{t.user_email || '—'}</td>
+                                                    <td className="py-2 pr-3 text-slate-700 dark:text-slate-200">
+                                                        {t.user_email || '—'}
+                                                        {t.needs_account && (
+                                                            <span className="block text-xs text-amber-600 dark:text-amber-400">
+                                                                payé sans compte
+                                                            </span>
+                                                        )}
+                                                    </td>
                                                     <td className="py-2 pr-3 text-slate-700 dark:text-slate-200">{t.plan_name}</td>
                                                     <td className="py-2 pr-3 text-slate-700 dark:text-slate-200">{money(t.amount, t.currency)}</td>
                                                     <td className="py-2 pr-3">
                                                         <Badge variant={t.status === 'completed' ? 'default' : 'secondary'}>{t.status}</Badge>
+                                                    </td>
+                                                    <td className="py-2 pr-3 text-right">
+                                                        {t.needs_account && (
+                                                            <Button
+                                                                size="sm"
+                                                                variant="outline"
+                                                                onClick={() => {
+                                                                    setAttachTx(t);
+                                                                    setAttachResult(null);
+                                                                    setAttachForm({ email: t.user_email || '', first_name: '', last_name: '' });
+                                                                }}
+                                                            >
+                                                                <UserPlus className="h-4 w-4 mr-1" /> Rattacher
+                                                            </Button>
+                                                        )}
                                                     </td>
                                                 </tr>
                                             ))}
@@ -833,6 +897,64 @@ export default function AdminCRM() {
                             <Trash2 className="h-4 w-4 mr-2" /> Supprimer le compte
                         </Button>
                         <Button variant="outline" size="sm" onClick={() => setDetail(null)}>Fermer</Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+
+            {/* ===== Rattacher un paiement à un compte ===== */}
+            <Dialog open={!!attachTx} onOpenChange={(open) => { if (!open) { setAttachTx(null); setAttachResult(null); } }}>
+                <DialogContent className="max-w-md">
+                    <DialogHeader>
+                        <DialogTitle>Rattacher le paiement à un compte</DialogTitle>
+                        <DialogDescription>
+                            {attachTx && (
+                                <>{money(attachTx.amount, attachTx.currency)} — {attachTx.plan_name} — {date(attachTx.created_at)}</>
+                            )}
+                        </DialogDescription>
+                    </DialogHeader>
+
+                    {attachResult ? (
+                        <div className="space-y-3">
+                            <p className="text-sm text-slate-700 dark:text-slate-200">
+                                Abonnement ouvert pour <strong>{attachResult.user.email}</strong>
+                                {attachResult.subscription?.end_date && <> jusqu'au {date(attachResult.subscription.end_date)}</>}.
+                            </p>
+                            {attachResult.temporary_password && (
+                                <div className="rounded-xl border border-amber-300 bg-amber-50 dark:bg-amber-500/10 dark:border-amber-500/30 p-3">
+                                    <div className="text-xs text-amber-700 dark:text-amber-300 mb-1">
+                                        Mot de passe provisoire à communiquer à l'élève (affiché une seule fois) :
+                                    </div>
+                                    <code className="text-sm font-mono text-slate-900 dark:text-white">
+                                        {attachResult.temporary_password}
+                                    </code>
+                                </div>
+                            )}
+                        </div>
+                    ) : (
+                        <div className="space-y-3">
+                            <p className="text-sm text-slate-500 dark:text-slate-400">
+                                Le compte est créé s'il n'existe pas encore ; s'il existe déjà, le paiement lui est
+                                simplement rattaché.
+                            </p>
+                            <Input placeholder="Email de l'élève" type="email" value={attachForm.email}
+                                onChange={(e) => setAttachForm((f) => ({ ...f, email: e.target.value }))} />
+                            <div className="grid grid-cols-2 gap-2">
+                                <Input placeholder="Prénom" value={attachForm.first_name}
+                                    onChange={(e) => setAttachForm((f) => ({ ...f, first_name: e.target.value }))} />
+                                <Input placeholder="Nom" value={attachForm.last_name}
+                                    onChange={(e) => setAttachForm((f) => ({ ...f, last_name: e.target.value }))} />
+                            </div>
+                        </div>
+                    )}
+
+                    <DialogFooter>
+                        {attachResult ? (
+                            <Button size="sm" onClick={() => { setAttachTx(null); setAttachResult(null); }}>Fermer</Button>
+                        ) : (
+                            <Button size="sm" onClick={attachTransaction} disabled={attachSaving || !attachForm.email.trim()}>
+                                <UserPlus className="h-4 w-4 mr-2" /> {attachSaving ? 'Rattachement…' : 'Rattacher et ouvrir l\'accès'}
+                            </Button>
+                        )}
                     </DialogFooter>
                 </DialogContent>
             </Dialog>

--- a/frontend/src/pages/PaymentSuccess.js
+++ b/frontend/src/pages/PaymentSuccess.js
@@ -1,17 +1,121 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import axios from 'axios';
+import { useAuth } from '../context/AuthContext';
 import { Button } from '../components/ui/button';
-import { CheckCircle, Home, DollarSign, Calendar, Package } from 'lucide-react';
+import { CheckCircle, Home, DollarSign, Calendar, Package, KeyRound, Eye, EyeOff, Loader2 } from 'lucide-react';
 
 // Constants for polling configuration
 const MAX_POLLING_ATTEMPTS = 10;
 const POLLING_INTERVAL_MS = 2000;
 const AUTO_REDIRECT_DELAY_MS = 7000;
 
+/**
+ * Dernière étape quand un paiement est arrivé sans compte rattaché : l'élève
+ * choisit son mot de passe ici et entre directement sur la plateforme. Sans ce
+ * formulaire, il se retrouve devant une page de connexion pour un compte qui
+ * n'existe pas.
+ */
+function ClaimAccessForm({ transactionId, emailHint, onDone }) {
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+
+  const submit = async (e) => {
+    e.preventDefault();
+    setError(null);
+    if (password.length < 6) {
+      setError('Ton mot de passe doit contenir au moins 6 caractères.');
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const { data } = await axios.post('/api/payments/hyp/claim', {
+        transaction_id: transactionId,
+        email: email.trim(),
+        password,
+        first_name: firstName.trim() || null,
+        last_name: lastName.trim() || null,
+      });
+      await onDone(data.access_token);
+    } catch (err) {
+      setError(err?.response?.data?.detail || "Impossible de finaliser ton accès. Réessaie ou contacte-nous.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const field = "w-full rounded-xl bg-white/[0.06] border border-white/[0.12] px-3 py-2.5 text-sm text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-emerald-500";
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-slate-950 p-6">
+      <div className="max-w-md w-full bg-white/[0.03] backdrop-blur-xl border border-white/[0.05] rounded-2xl shadow-xl p-8">
+        <div className="mx-auto mb-5 flex items-center justify-center h-16 w-16 rounded-full bg-emerald-500/10">
+          <CheckCircle className="h-10 w-10 text-emerald-500" />
+        </div>
+
+        <h1 className="text-2xl font-bold text-white text-center mb-2">Paiement bien reçu !</h1>
+        <p className="text-slate-300 text-center mb-1">
+          Dernière étape : choisis ton mot de passe pour ouvrir ton accès.
+        </p>
+        <p className="text-slate-500 text-sm text-center mb-6">
+          {emailHint
+            ? <>Utilise de préférence l'email du paiement ({emailHint}).</>
+            : "Utilise de préférence l'email indiqué lors du paiement."}
+        </p>
+
+        <form onSubmit={submit} className="space-y-3">
+          <div className="grid grid-cols-2 gap-3">
+            <input className={field} placeholder="Prénom" autoComplete="given-name" autoFocus
+              value={firstName} onChange={(e) => setFirstName(e.target.value)} required />
+            <input className={field} placeholder="Nom" autoComplete="family-name"
+              value={lastName} onChange={(e) => setLastName(e.target.value)} required />
+          </div>
+          <input className={field} type="email" placeholder="Ton email" autoComplete="email" inputMode="email"
+            value={email} onChange={(e) => setEmail(e.target.value)} required />
+          <div className="relative">
+            <input
+              className={`${field} pr-11`}
+              type={showPassword ? 'text' : 'password'}
+              placeholder="Choisis ton mot de passe (6 caractères minimum)"
+              autoComplete="new-password"
+              minLength={6}
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+            />
+            <button type="button" onClick={() => setShowPassword((v) => !v)}
+              aria-label={showPassword ? 'Masquer le mot de passe' : 'Afficher le mot de passe'}
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-white">
+              {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+            </button>
+          </div>
+
+          {error && <p className="text-sm text-red-400">{error}</p>}
+
+          <Button type="submit" disabled={submitting} className="w-full bg-emerald-600 hover:bg-emerald-700">
+            {submitting
+              ? <Loader2 className="h-5 w-5 animate-spin" />
+              : <span className="flex items-center gap-2"><KeyRound className="h-4 w-4" /> Activer mon accès</span>}
+          </Button>
+        </form>
+
+        <p className="mt-5 text-xs text-slate-500 text-center">
+          Ton abonnement est déjà payé : ce mot de passe est celui qui te servira à te connecter.
+        </p>
+      </div>
+    </div>
+  );
+}
+
 function PaymentSuccess() {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
+  const { user, loginWithToken } = useAuth();
   const [transaction, setTransaction] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -22,6 +126,8 @@ function PaymentSuccess() {
   const transactionId = searchParams.get('transaction_id') || searchParams.get('Order');
 
   useEffect(() => {
+    let cancelled = false;
+
     // If HYP redirected the browser here with a result payload (CCode present),
     // forward it to the backend callback so the subscription is provisioned even
     // when the server-to-server notification is not configured. Verification is
@@ -38,6 +144,7 @@ function PaymentSuccess() {
 
     // Fetch transaction details with polling
     const fetchTransaction = async (attempt = 0) => {
+      if (cancelled) return;
       if (!transactionId) {
         setError('ID de transaction manquant');
         setLoading(false);
@@ -46,7 +153,7 @@ function PaymentSuccess() {
 
       try {
         const response = await axios.get(`/api/payments/hyp/transaction/${transactionId}`);
-        
+
         // Check if callback has been processed (transaction completed)
         if (response.data.status === 'completed' || attempt >= MAX_POLLING_ATTEMPTS) {
           setTransaction(response.data);
@@ -58,7 +165,7 @@ function PaymentSuccess() {
         }
       } catch (err) {
         console.error('Error fetching transaction:', err);
-        
+
         // Retry on error if not too many attempts
         if (attempt < MAX_POLLING_ATTEMPTS) {
           setPollAttempt(attempt + 1);
@@ -73,13 +180,23 @@ function PaymentSuccess() {
     // Trigger provisioning first (best-effort), then start polling.
     notifyBackend().finally(() => fetchTransaction());
 
-    // Auto-redirect to training page after configured delay
-    const timer = setTimeout(() => {
-      navigate('/training');
-    }, AUTO_REDIRECT_DELAY_MS);
+    return () => { cancelled = true; };
+  }, [transactionId, searchParams]);
 
+  // La redirection automatique n'a lieu que si l'élève peut réellement entrer :
+  // connecté et abonnement ouvert. Sinon, il resterait bloqué sur une page de
+  // connexion sans savoir quoi faire.
+  const canEnter = !!user && !!transaction && !transaction.needs_account;
+  useEffect(() => {
+    if (!canEnter) return;
+    const timer = setTimeout(() => navigate('/training'), AUTO_REDIRECT_DELAY_MS);
     return () => clearTimeout(timer);
-  }, [transactionId, navigate, searchParams]);
+  }, [canEnter, navigate]);
+
+  const handleClaimed = useCallback(async (accessToken) => {
+    await loginWithToken(accessToken);
+    navigate('/training');
+  }, [loginWithToken, navigate]);
 
   // Format date in French format
   const formatDate = (dateString) => {
@@ -127,6 +244,17 @@ function PaymentSuccess() {
     );
   }
 
+  // Paiement encaissé sans compte : on ouvre l'accès ici, tout de suite.
+  if (transaction?.needs_account) {
+    return (
+      <ClaimAccessForm
+        transactionId={transaction.id}
+        emailHint={transaction.email_hint}
+        onDone={handleClaimed}
+      />
+    );
+  }
+
   return (
     <div className="min-h-screen flex items-center justify-center bg-slate-950 p-6">
       <div className="max-w-md w-full bg-white/[0.03] backdrop-blur-xl border border-white/[0.05] rounded-2xl shadow-xl p-8 text-center">
@@ -139,11 +267,13 @@ function PaymentSuccess() {
 
         {/* Success Message */}
         <h1 className="text-3xl font-bold text-white mb-4">
-          Payment Successful!
+          Paiement réussi !
         </h1>
-        
+
         <p className="text-slate-300 mb-6">
-          Votre abonnement a été activé avec succès.
+          {transaction?.status === 'completed'
+            ? 'Ton abonnement est activé.'
+            : "Ton paiement est en cours de validation : ton accès s'ouvrira dans quelques instants."}
         </p>
 
         {/* Transaction Details */}
@@ -163,20 +293,20 @@ function PaymentSuccess() {
                   {transaction.amount}₪
                 </span>
               </div>
-              
+
               {/* Subscription info with icon */}
               {transaction.subscription ? (
                 <>
                   <div className="flex justify-between items-center">
                     <span className="text-slate-400 flex items-center gap-2">
                       <Package className="h-4 w-4" />
-                      Plan :
+                      Formule :
                     </span>
                     <span className="font-medium text-white">
                       {transaction.subscription.plan_name}
                     </span>
                   </div>
-                  
+
                   {/* End date with icon */}
                   {transaction.subscription.end_date && (
                     <div className="flex justify-between items-center">
@@ -189,7 +319,7 @@ function PaymentSuccess() {
                       </span>
                     </div>
                   )}
-                  
+
                   <div className="flex justify-between">
                     <span className="text-slate-400">Statut :</span>
                     <span className="font-medium text-emerald-500">
@@ -199,20 +329,20 @@ function PaymentSuccess() {
                 </>
               ) : (
                 <div className="flex justify-between">
-                  <span className="text-slate-400">Plan :</span>
+                  <span className="text-slate-400">Formule :</span>
                   <span className="font-medium text-white">
-                    {transaction.plan_id}
+                    {transaction.plan_name || transaction.plan_id}
                   </span>
                 </div>
               )}
-              
+
               <div className="flex justify-between">
                 <span className="text-slate-400">Date :</span>
                 <span className="font-medium text-white">
                   {formatDate(transaction.created_at || new Date().toISOString())}
                 </span>
               </div>
-              
+
               <div className="flex justify-between">
                 <span className="text-slate-400">ID :</span>
                 <span className="font-mono text-xs text-white">
@@ -225,32 +355,50 @@ function PaymentSuccess() {
 
         {/* Action Buttons */}
         <div className="space-y-3">
-          <Button 
-            onClick={() => navigate('/training')} 
-            className="w-full bg-emerald-600 hover:bg-emerald-700 transition-colors"
-          >
-            Access My Training
-          </Button>
-          
+          {user ? (
+            <>
+              <Button
+                onClick={() => navigate('/training')}
+                className="w-full bg-emerald-600 hover:bg-emerald-700 transition-colors"
+              >
+                Accéder à mon entraînement
+              </Button>
+              <p className="text-sm text-slate-500">
+                Redirection automatique dans 7 secondes...
+              </p>
+            </>
+          ) : (
+            // Abonnement rattaché à un compte, mais la session a été perdue en
+            // route (paiement sur un autre appareil, navigateur relancé…).
+            <>
+              <Button
+                onClick={() => navigate('/login')}
+                className="w-full bg-emerald-600 hover:bg-emerald-700 transition-colors"
+              >
+                Me connecter pour commencer
+              </Button>
+              <p className="text-sm text-slate-400">
+                Connecte-toi avec l'email et le mot de passe choisis avant le paiement.
+              </p>
+            </>
+          )}
+
           <button
             onClick={() => navigate('/')}
             className="w-full flex items-center justify-center gap-2 text-slate-400 hover:text-white transition-colors text-sm"
           >
             <Home className="h-4 w-4" />
-            Back to Home
+            Retour à l'accueil
           </button>
-          
-          <p className="text-sm text-slate-500">
-            Redirection automatique dans 7 secondes...
-          </p>
         </div>
 
         {/* Additional Info */}
         <div className="mt-6 pt-6 border-t border-white/[0.05]">
           <p className="text-xs text-slate-400">
-            Un email de confirmation vous a été envoyé.
+            Un reçu de paiement t'a été envoyé par email.
             <br />
-            Vous pouvez commencer à utiliser votre abonnement immédiatement.
+            Un souci pour accéder à ton abonnement ? Contacte-nous en indiquant
+            l'identifiant de paiement ci-dessus.
           </p>
         </div>
       </div>

--- a/frontend/src/pages/Pricing.js
+++ b/frontend/src/pages/Pricing.js
@@ -2,32 +2,159 @@ import React, { useState } from "react";
 import axios from "axios";
 import { HYP_CONFIG } from '../config/hypConfig';
 import { useAuth } from "../context/AuthContext";
+import { toast } from "sonner";
 import {
   Zap, FileCheck, LineChart, BookOpen, HelpCircle, History,
   Crown, Check, Star, ShieldCheck, MonitorSmartphone, GraduationCap,
-  ArrowRight, Loader2, BadgeCheck,
+  ArrowRight, Loader2, BadgeCheck, X, Eye, EyeOff, UserPlus, LogIn,
 } from "lucide-react";
 
-async function startHypCheckout(planId, userEmail = null, userId = null, promoCode = null) {
+// Renvoie le statut HTTP en cas d'échec pour que l'appelant puisse réagir
+// (401 = session perdue : on redemande le compte plutôt que d'afficher une
+// erreur sèche).
+async function startHypCheckout(planId, promoCode = null) {
   try {
     const res = await axios.post('/api/payments/hyp/create-payment', {
-      plan_id: planId, user_email: userEmail, user_id: userId,
-      promo_code: promoCode || null,
+      plan_id: planId, promo_code: promoCode || null,
     });
     // Code offrant 100 % : aucun paiement, l'accès est déjà activé côté serveur.
+    // L'identifiant de transaction suit, sinon la page de confirmation n'a rien
+    // à afficher.
     if (res.data?.free) {
-      window.location.href = '/payment/success?free=1';
-      return;
+      window.location.href = `/payment/success?free=1&transaction_id=${res.data.transaction_id}`;
+      return { ok: true };
     }
     const paymentUrl = res.data?.payment_url;
     if (paymentUrl) {
       window.location.href = paymentUrl;
-    } else {
-      alert('❌ Erreur : URL de paiement non disponible');
+      return { ok: true };
     }
+    toast.error("URL de paiement indisponible. Réessaie dans un instant.");
+    return { ok: false };
   } catch (e) {
-    alert(`❌ Erreur de paiement : ${e?.response?.data?.detail || 'Erreur inconnue'}`);
+    const status = e?.response?.status;
+    if (status !== 401) {
+      toast.error(`Erreur de paiement : ${e?.response?.data?.detail || 'erreur inconnue'}`);
+    }
+    return { ok: false, status };
   }
+}
+
+/**
+ * Compte obligatoire AVANT le paiement.
+ *
+ * Un abonnement n'existe que rattaché à un compte : si l'élève paie sans en
+ * avoir un, l'argent est encaissé mais aucun accès ne peut être ouvert, et on
+ * lui demande ensuite de se connecter à un compte qu'il n'a jamais créé. Le
+ * mot de passe est donc choisi ici, avant la redirection vers la banque, puis
+ * le paiement reprend tout seul.
+ */
+function AccountGate({ planLabel, onClose, onReady }) {
+  const { register, login } = useAuth();
+  const [mode, setMode] = useState('register');   // register | login
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+
+  const isRegister = mode === 'register';
+
+  const submit = async (e) => {
+    e.preventDefault();
+    setError(null);
+    if (isRegister && password.length < 6) {
+      setError("Ton mot de passe doit contenir au moins 6 caractères.");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      if (isRegister) {
+        await register(email.trim(), password, firstName.trim(), lastName.trim());
+      } else {
+        await login(email.trim(), password);
+      }
+      onReady();
+    } catch (err) {
+      const detail = err?.response?.data?.detail;
+      setError(
+        detail ||
+        (isRegister
+          ? "Impossible de créer le compte. Cet email est peut-être déjà utilisé."
+          : "Email ou mot de passe incorrect.")
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const field = "w-full rounded-xl bg-white/10 border border-white/15 px-3 py-2.5 text-sm text-white placeholder-white/40 focus:outline-none focus:ring-2 focus:ring-yellow-400";
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm p-4 overflow-y-auto">
+      <div className="w-full max-w-md rounded-3xl bg-[#0c1a2e] border border-white/15 p-6 shadow-2xl my-8">
+        <div className="flex items-start justify-between gap-4 mb-1">
+          <h3 className="text-xl font-extrabold text-white">
+            {isRegister ? 'Crée ton compte pour continuer' : 'Connecte-toi pour continuer'}
+          </h3>
+          <button type="button" onClick={onClose} aria-label="Fermer" className="text-white/60 hover:text-white">
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+        <p className="text-sm text-white/70 mb-5">
+          Ton abonnement <strong className="text-yellow-300">{planLabel}</strong> sera rattaché à ce compte.
+          {isRegister && " Choisis ton mot de passe maintenant : c'est avec lui que tu te connecteras juste après le paiement."}
+        </p>
+
+        <form onSubmit={submit} className="space-y-3">
+          {isRegister && (
+            <div className="grid grid-cols-2 gap-3">
+              <input className={field} placeholder="Prénom" autoComplete="given-name" autoFocus
+                value={firstName} onChange={(e) => setFirstName(e.target.value)} required />
+              <input className={field} placeholder="Nom" autoComplete="family-name"
+                value={lastName} onChange={(e) => setLastName(e.target.value)} required />
+            </div>
+          )}
+          <input className={field} type="email" placeholder="Ton email" autoComplete="email" inputMode="email"
+            autoFocus={!isRegister} value={email} onChange={(e) => setEmail(e.target.value)} required />
+          <div className="relative">
+            <input
+              className={`${field} pr-11`}
+              type={showPassword ? 'text' : 'password'}
+              placeholder={isRegister ? 'Mot de passe (6 caractères minimum)' : 'Ton mot de passe'}
+              autoComplete={isRegister ? 'new-password' : 'current-password'}
+              minLength={isRegister ? 6 : undefined}
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+            />
+            <button type="button" onClick={() => setShowPassword((v) => !v)}
+              aria-label={showPassword ? 'Masquer le mot de passe' : 'Afficher le mot de passe'}
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-white/60 hover:text-white">
+              {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+            </button>
+          </div>
+
+          {error && <p className="text-sm text-red-300">{error}</p>}
+
+          <button type="submit" disabled={submitting}
+            className="w-full rounded-xl bg-yellow-400 hover:bg-yellow-300 text-slate-900 font-bold py-3 transition-colors flex items-center justify-center gap-2 disabled:opacity-60">
+            {submitting
+              ? <Loader2 className="h-5 w-5 animate-spin" />
+              : <>{isRegister ? <UserPlus className="h-4 w-4" /> : <LogIn className="h-4 w-4" />} Continuer vers le paiement</>}
+          </button>
+        </form>
+
+        <button type="button"
+          onClick={() => { setMode(isRegister ? 'login' : 'register'); setError(null); }}
+          className="mt-4 w-full text-sm text-white/70 hover:text-white underline underline-offset-4">
+          {isRegister ? "J'ai déjà un compte" : "Je n'ai pas encore de compte"}
+        </button>
+      </div>
+    </div>
+  );
 }
 
 const HIGHLIGHTS = [
@@ -144,7 +271,7 @@ function DurationOptions({ options, selected, onSelect, accent }) {
 }
 
 function Pricing() {
-  const { user } = useAuth();
+  const { user, logout } = useAuth();
   const [loading, setLoading] = useState(null);
   const [standardSel, setStandardSel] = useState(HYP_CONFIG.plans.BASIC.DAYS_30);
   const [premiumSel, setPremiumSel] = useState(HYP_CONFIG.plans.PREMIUM.DAYS_30);
@@ -152,15 +279,37 @@ function Pricing() {
   const [promoApplied, setPromoApplied] = useState(null);
   const [promoMessage, setPromoMessage] = useState(null);
   const [promoChecking, setPromoChecking] = useState(false);
+  // Formule choisie en attendant que l'élève ait un compte.
+  const [pendingPlan, setPendingPlan] = useState(null);
 
-  const checkout = async (planId) => {
+  const goToPayment = async (planId) => {
     setLoading(planId);
     try {
-      await startHypCheckout(planId, user?.email || null, user?.id || null, promoApplied?.code || null);
+      const result = await startHypCheckout(planId, promoApplied?.code || null);
+      // Session perdue ou expirée entre-temps : on redemande le compte plutôt
+      // que de laisser l'élève devant un message d'erreur.
+      if (!result.ok && result.status === 401) {
+        toast.info('Reconnecte-toi pour finaliser ton abonnement.');
+        setPendingPlan(planId);
+      }
     } finally {
       setLoading(null);
     }
   };
+
+  const checkout = async (planId) => {
+    // Pas de compte, pas de paiement : sinon l'abonnement encaissé ne peut être
+    // rattaché à personne. La formule est mémorisée et le paiement repart seul
+    // dès que le compte est prêt.
+    if (!user) {
+      setPendingPlan(planId);
+      return;
+    }
+    await goToPayment(planId);
+  };
+
+  const planLabel = (planId) =>
+    [...standardOptions, ...premiumOptions].find((o) => o.planId === planId)?.label || 'Flash Neiga';
 
   // Vérifie le code auprès du serveur pour afficher le prix remisé.
   // Le montant réellement facturé est recalculé côté serveur au paiement.
@@ -189,14 +338,14 @@ function Pricing() {
   };
 
   const standardOptions = [
-    { planId: HYP_CONFIG.plans.BASIC.DAYS_14, price: 69, duration: '14 jours' },
-    { planId: HYP_CONFIG.plans.BASIC.DAYS_21, price: 89, duration: '21 jours' },
-    { planId: HYP_CONFIG.plans.BASIC.DAYS_30, price: 99, duration: '30 jours' },
+    { planId: HYP_CONFIG.plans.BASIC.DAYS_14, price: 69, duration: '14 jours', label: 'Standard 14 jours' },
+    { planId: HYP_CONFIG.plans.BASIC.DAYS_21, price: 89, duration: '21 jours', label: 'Standard 21 jours' },
+    { planId: HYP_CONFIG.plans.BASIC.DAYS_30, price: 99, duration: '30 jours', label: 'Standard 30 jours' },
   ];
   const premiumOptions = [
-    { planId: HYP_CONFIG.plans.PREMIUM.DAYS_14, price: 119, duration: '14 jours' },
-    { planId: HYP_CONFIG.plans.PREMIUM.DAYS_21, price: 139, duration: '21 jours' },
-    { planId: HYP_CONFIG.plans.PREMIUM.DAYS_30, price: 149, duration: '30 jours' },
+    { planId: HYP_CONFIG.plans.PREMIUM.DAYS_14, price: 119, duration: '14 jours', label: 'Premium 14 jours' },
+    { planId: HYP_CONFIG.plans.PREMIUM.DAYS_21, price: 139, duration: '21 jours', label: 'Premium 21 jours' },
+    { planId: HYP_CONFIG.plans.PREMIUM.DAYS_30, price: 149, duration: '30 jours', label: 'Premium 30 jours' },
   ];
 
   return (
@@ -222,7 +371,17 @@ function Pricing() {
                 </div>
               </div>
             </div>
-            <a href="/login" className="text-sm text-white/70 hover:text-white underline underline-offset-4">Se connecter</a>
+            {user ? (
+              <div className="text-right text-sm">
+                <div className="text-white/60 text-xs">Abonnement rattaché à</div>
+                <div className="text-white font-semibold">{user.email}</div>
+                <button type="button" onClick={logout} className="text-white/50 hover:text-white text-xs underline underline-offset-2">
+                  Ce n'est pas moi
+                </button>
+              </div>
+            ) : (
+              <a href="/login" className="text-sm text-white/70 hover:text-white underline underline-offset-4">Se connecter</a>
+            )}
           </div>
 
           <div className="max-w-2xl">
@@ -283,9 +442,14 @@ function Pricing() {
 
         {/* Formules */}
         <div>
-          <h2 className="text-center text-2xl md:text-3xl font-extrabold mb-6">
+          <h2 className="text-center text-2xl md:text-3xl font-extrabold mb-2">
             Choisis ta formule et avance à ton rythme
           </h2>
+          <p className="text-center text-sm text-white/60 mb-6">
+            {user
+              ? <>Ton abonnement sera activé sur ton compte <strong className="text-white/80">{user.email}</strong> dès le paiement validé.</>
+              : "Tu choisiras ton mot de passe juste avant le paiement : ton accès est activé immédiatement après."}
+          </p>
 
           <div className="grid md:grid-cols-2 gap-6 items-start">
 
@@ -396,6 +560,18 @@ function Pricing() {
           <Zap className="h-6 w-6 fill-slate-900" aria-hidden="true" />
         </div>
       </div>
+
+      {pendingPlan && (
+        <AccountGate
+          planLabel={planLabel(pendingPlan)}
+          onClose={() => setPendingPlan(null)}
+          onReady={() => {
+            const planId = pendingPlan;
+            setPendingPlan(null);
+            goToPayment(planId);
+          }}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Un élève pouvait payer sans avoir de compte : l'argent était encaissé, aucun abonnement ne pouvait être ouvert (il n'a pas de propriétaire), et la page de confirmation lui demandait ensuite de se connecter à un compte qu'il n'avait jamais créé — avec un mot de passe qu'il n'avait jamais choisi.

Prévention :
- /pricing demande de créer le compte (ou de se connecter) avant la redirection vers HYP, puis relance le paiement tout seul ;
- create-payment exige un compte : l'identité vient du token, jamais du corps de la requête (le user_id envoyé par le client ne peut plus désigner un tiers) ;
- l'email est conservé sur toutes les transactions, pas seulement celles avec un code promo.

Rattrapage :
- la page de confirmation détecte un paiement sans compte et propose de choisir son mot de passe : POST /payments/hyp/claim crée le compte, ouvre l'abonnement payé et connecte l'élève (un paiement déjà rattaché ne peut pas être repris ; sur un compte existant, son mot de passe est exigé) ;
- le CRM signale ces paiements et permet de les rattacher à un compte, avec un mot de passe provisoire à transmettre ;
- la redirection automatique vers l'entraînement n'a plus lieu que si l'élève peut réellement entrer.

Connexion :
- emails normalisés à l'inscription et recherche insensible à la casse, y compris pour les comptes existants ;
- longueur minimale du mot de passe contrôlée côté serveur.

La création d'abonnement est isolée dans provision_subscription(), partagée par le callback HYP, le code promo à 100 %, /claim et le CRM.